### PR TITLE
driver: make the undecoded-image fallback announce itself

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ alpasim = [
     "pyarrow>=16",
 ]
 viz = ["Pillow>=10", "matplotlib>=3.8"]
+# Serving the gRPC driver against a real simulator: every rollout streams JPEG
+# camera frames, which need a decoder.
+driver = ["Pillow>=10"]
 
 [project.entry-points."alpasim.models"]
 constant_velocity = "alpabridge.simulator.baseline_drivers:ConstantVelocityAlpaSimModel"

--- a/src/alpabridge/driver/driver_service.py
+++ b/src/alpabridge/driver/driver_service.py
@@ -725,16 +725,42 @@ def _finite_vec2(value: Any) -> tuple[float, float] | None:
     return parsed if all(math.isfinite(item) for item in parsed) else None
 
 
+_FALLBACK_WARNINGS: set[str] = set()
+
+
+def _warn_once(key: str, message: str) -> None:
+    if key not in _FALLBACK_WARNINGS:
+        _FALLBACK_WARNINGS.add(key)
+        LOGGER.warning(message)
+
+
 def _image_array_from_bytes(image_bytes: bytes) -> np.ndarray:
     if not image_bytes:
         return np.zeros((1,), dtype=np.uint8)
+
     try:
         from io import BytesIO
 
         from PIL import Image
+    except ImportError:
+        # Distinct from a bad frame: without a decoder every frame for the rest
+        # of the process degrades, so say so once rather than per frame.
+        _warn_once(
+            "pillow-missing",
+            "Pillow is not installed, so camera frames reach policies as raw undecoded "
+            "bytes rather than an RGB array. Install alpabridge[driver] for any policy "
+            "that reads pixels.",
+        )
+        return np.frombuffer(image_bytes, dtype=np.uint8)
 
+    try:
         return np.asarray(Image.open(BytesIO(image_bytes)).convert("RGB"))
     except Exception:
+        _warn_once(
+            "image-decode-failed",
+            "Could not decode a camera frame; passing raw bytes through instead. "
+            "Further decode failures are not logged.",
+        )
         return np.frombuffer(image_bytes, dtype=np.uint8)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,9 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+driver = [
+    { name = "pillow" },
+]
 viz = [
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "matplotlib", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -42,6 +45,7 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'alpasim'", specifier = ">=0.30" },
     { name = "matplotlib", marker = "extra == 'viz'", specifier = ">=3.8" },
     { name = "numpy", specifier = ">=1.26" },
+    { name = "pillow", marker = "extra == 'driver'", specifier = ">=10" },
     { name = "pillow", marker = "extra == 'viz'", specifier = ">=10" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },
     { name = "pyarrow", marker = "extra == 'alpasim'", specifier = ">=16" },
@@ -50,7 +54,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
 ]
-provides-extras = ["dev", "alpasim", "viz"]
+provides-extras = ["dev", "alpasim", "viz", "driver"]
 
 [[package]]
 name = "anyio"
@@ -129,7 +133,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -200,7 +204,7 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
@@ -404,7 +408,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -598,7 +602,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.11'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -746,15 +750,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "cycler", marker = "python_full_version < '3.11'" },
-    { name = "fonttools", marker = "python_full_version < '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pillow", marker = "python_full_version < '3.11'" },
-    { name = "pyparsing", marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -823,16 +827,16 @@ resolution-markers = [
     "python_full_version == '3.11.*'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "cycler", marker = "python_full_version >= '3.11'" },
-    { name = "fonttools", marker = "python_full_version >= '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pillow", marker = "python_full_version >= '3.11'" },
-    { name = "pyparsing", marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/64/f9a391af28f518b11ad45a8a712353c94a0aefce09d3703200e5c54b610a/matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30", size = 32612045, upload-time = "2026-07-18T03:39:46.63Z" }
 wheels = [


### PR DESCRIPTION
Make the undecoded-image fallback announce itself.

`_image_array_from_bytes` catches every exception and falls back to `np.frombuffer` on the raw bytes. Reasonable for one corrupt frame, but it also swallows `ImportError`: without Pillow, every frame for the rest of the process reaches the policy as a 1-D byte array, silently. A policy that ignores pixels passes anyway, so the missing dependency surfaces only as unexplained behaviour in one that doesn't.

Split the two failure modes and warn once for each; the fallback itself is unchanged. Adds a `driver` extra declaring Pillow, since serving real camera frames always needs a decoder.
