### PR TITLE
driver: load the policy off the serving critical path

### DIFF
--- a/src/alpabridge/driver/driver_service.py
+++ b/src/alpabridge/driver/driver_service.py
@@ -29,6 +29,15 @@ LOGGER = logging.getLogger("alpabridge_driver_service")
 DRIVER_TELEMETRY_SCHEMA = "alpabridge_driver_telemetry_v3"
 
 
+class ModelLoadError(RuntimeError):
+    """The policy could not be constructed.
+
+    Distinct from a RuntimeError raised by a working policy, so the gRPC layer
+    can report a driver that will never serve as FAILED_PRECONDITION rather than
+    misreporting it as a malformed request.
+    """
+
+
 @dataclass
 class DriverCameraFrame:
     timestamp_us: int
@@ -197,13 +206,19 @@ class AlpaBridgeDriverService:
         """Return the policy, waiting for a deferred load and failing loudly."""
         if self._model is not None:
             return self._model
-        timeout_s = float(os.getenv("ALPABRIDGE_DRIVER_MODEL_LOAD_TIMEOUT_S", "600"))
+        # This wait happens inside drive(), which is budgeted at 100 ms, and the
+        # AlpaSim E2E challenge caps a whole PAI evaluation at ~1031 s wall of
+        # which only ~250 s is driver time. Blocking here for minutes would end
+        # the run rather than rescue it, so the default is a small fraction of
+        # that budget: better to fail one call as UNAVAILABLE than to spend the
+        # evaluation waiting.
+        timeout_s = float(os.getenv("ALPABRIDGE_DRIVER_MODEL_LOAD_TIMEOUT_S", "30"))
         if not self._model_ready.wait(timeout_s):
             raise TimeoutError(
                 f"policy {self.model_name} still loading after {timeout_s:.0f}s"
             )
         if self._model_error is not None:
-            raise RuntimeError(
+            raise ModelLoadError(
                 f"policy {self.model_name} failed to load: {self._model_error!r}"
             ) from self._model_error
         return self._model
@@ -988,6 +1003,12 @@ def _build_service_class(
             except TimeoutError as exc:
                 # Still loading: retryable, and distinct from a bad request.
                 context.abort(grpc.StatusCode.UNAVAILABLE, str(exc))
+                raise AssertionError("unreachable") from exc
+            except ModelLoadError as exc:
+                # The policy will never serve. Not retryable, and emphatically
+                # not the caller's fault, so neither UNAVAILABLE nor a bad request.
+                LOGGER.error("AlpaBridge driver has no usable policy: %s", exc)
+                context.abort(grpc.StatusCode.FAILED_PRECONDITION, str(exc))
                 raise AssertionError("unreachable") from exc
             except Exception as exc:
                 LOGGER.exception("AlpaBridge driver Drive failed")

--- a/src/alpabridge/driver/driver_service.py
+++ b/src/alpabridge/driver/driver_service.py
@@ -111,6 +111,7 @@ class AlpaBridgeDriverService:
         tokenizer_checkpoint_path: str | Path | None = None,
         device: str = "cpu",
         route_contract_mode: str | None = None,
+        defer_model_load: bool = False,
     ) -> None:
         self.model_name = _normalize_model_name(model_name)
         self.camera_candidates = tuple(camera_ids)
@@ -150,7 +151,62 @@ class AlpaBridgeDriverService:
         self._lock = threading.RLock()
         self._sessions: dict[str, DriverSessionState] = {}
         self._telemetry = DriverTelemetry(telemetry_path)
-        self._model = self._build_model()
+
+        # Loading can be slow for checkpoint-backed policies. When deferred, the
+        # caller is free to bind and serve the gRPC port first, so readiness
+        # probes are answerable while the weights are still loading.
+        self._model: Any = None
+        self._model_error: BaseException | None = None
+        self._model_ready = threading.Event()
+        if defer_model_load:
+            threading.Thread(
+                target=self._load_model_in_background,
+                name="alpabridge-model-load",
+                daemon=True,
+            ).start()
+        else:
+            self._model = self._build_model()
+            self._model_ready.set()
+
+    def _load_model_in_background(self) -> None:
+        started = time.perf_counter()
+        try:
+            model = self._build_model()
+        except BaseException as exc:  # noqa: BLE001 - re-raised to callers of _require_model
+            self._model_error = exc
+            LOGGER.exception("AlpaBridge policy %s failed to load", self.model_name)
+            self._telemetry.record({"event": "model_load_failed", "error": repr(exc)})
+        else:
+            self._model = model
+            LOGGER.info(
+                "AlpaBridge policy %s loaded in %.1fs",
+                self.model_name,
+                time.perf_counter() - started,
+            )
+            self._telemetry.record(
+                {"event": "model_loaded", "seconds": time.perf_counter() - started}
+            )
+        finally:
+            self._model_ready.set()
+
+    def wait_for_model(self, timeout_s: float | None = None) -> bool:
+        """Block until the policy is loaded. False if it is still not ready."""
+        return self._model_ready.wait(timeout_s)
+
+    def _require_model(self) -> Any:
+        """Return the policy, waiting for a deferred load and failing loudly."""
+        if self._model is not None:
+            return self._model
+        timeout_s = float(os.getenv("ALPABRIDGE_DRIVER_MODEL_LOAD_TIMEOUT_S", "600"))
+        if not self._model_ready.wait(timeout_s):
+            raise TimeoutError(
+                f"policy {self.model_name} still loading after {timeout_s:.0f}s"
+            )
+        if self._model_error is not None:
+            raise RuntimeError(
+                f"policy {self.model_name} failed to load: {self._model_error!r}"
+            ) from self._model_error
+        return self._model
 
     def start_session(self, request: Any) -> None:
         session_uuid = str(request.session_uuid)
@@ -241,12 +297,12 @@ class AlpaBridgeDriverService:
 
     def predict(self, session_uuid: str, *, time_now_us: int) -> ModelPrediction:
         prediction_input = self.prediction_input(session_uuid, time_now_us=time_now_us)
-        return self._model.predict(prediction_input)
+        return self._require_model().predict(prediction_input)
 
     def drive_once_to_proto(self, session_uuid: str, *, time_now_us: int, common_pb2: Any) -> Any:
         start_ns = time.perf_counter_ns()
         prediction_input = self.prediction_input(session_uuid, time_now_us=time_now_us)
-        prediction = self._model.predict(prediction_input)
+        prediction = self._require_model().predict(prediction_input)
         trajectory = prediction_to_proto_trajectory(
             prediction,
             current_pose=self.latest_pose(session_uuid),
@@ -929,6 +985,10 @@ def _build_service_class(
             except KeyError as exc:
                 context.abort(grpc.StatusCode.NOT_FOUND, str(exc))
                 raise AssertionError("unreachable") from exc
+            except TimeoutError as exc:
+                # Still loading: retryable, and distinct from a bad request.
+                context.abort(grpc.StatusCode.UNAVAILABLE, str(exc))
+                raise AssertionError("unreachable") from exc
             except Exception as exc:
                 LOGGER.exception("AlpaBridge driver Drive failed")
                 context.abort(grpc.StatusCode.INVALID_ARGUMENT, str(exc))
@@ -1015,6 +1075,15 @@ def main() -> None:
         )
         return
     grpc, api_version_message, common_pb2, egodriver_pb2, egodriver_pb2_grpc = _load_grpc_modules()
+    # Serving readiness is what the evaluator gates on, so load off the critical
+    # path by default and let the port come up immediately. Set
+    # ALPABRIDGE_DRIVER_EAGER_MODEL_LOAD=1 to load before serving, which surfaces
+    # construction errors at startup and is usually what you want locally.
+    eager = os.getenv("ALPABRIDGE_DRIVER_EAGER_MODEL_LOAD", "0").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
     adapter = AlpaBridgeDriverService(
         model_name=args.model,
         telemetry_path=args.telemetry_path,
@@ -1022,6 +1091,7 @@ def main() -> None:
         checkpoint_path=args.checkpoint,
         tokenizer_checkpoint_path=args.tokenizer_checkpoint,
         device=args.device,
+        defer_model_load=not eager,
     )
     service_cls = _build_service_class(
         grpc=grpc,

--- a/tests/test_driver_service.py
+++ b/tests/test_driver_service.py
@@ -15,7 +15,6 @@ from alpabridge.driver.driver_service import (
     DRIVER_TELEMETRY_SCHEMA,
     AlpaBridgeDriverService,
     ModelLoadError,
-    AlpaBridgeDriverService,
     prediction_to_proto_trajectory,
     run_self_test,
 )

--- a/tests/test_driver_service.py
+++ b/tests/test_driver_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import math
+import threading
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
@@ -12,6 +13,8 @@ import pytest
 
 from alpabridge.driver.driver_service import (
     DRIVER_TELEMETRY_SCHEMA,
+    AlpaBridgeDriverService,
+    ModelLoadError,
     AlpaBridgeDriverService,
     prediction_to_proto_trajectory,
     run_self_test,
@@ -493,3 +496,77 @@ def test_prediction_to_proto_trajectory_rejects_nonfinite_transformed_output() -
             time_now_us=10_000,
             common_pb2=_FakeCommonPb2,
         )
+
+
+class TestDeferredModelLoad:
+    """The evaluator gates on get_version answering within its readiness window
+    while several replicas cold-start on one GPU, so a slow policy load must not
+    hold the gRPC port. What must never happen is a driver that quietly serves
+    something other than the policy it claims."""
+
+    def test_eager_construction_is_unchanged(self) -> None:
+        service = AlpaBridgeDriverService(model_name="route_following")
+
+        assert service.wait_for_model(0) is True
+        assert service._require_model() is not None
+
+    def test_deferred_construction_returns_before_the_policy_is_ready(self) -> None:
+        release = threading.Event()
+        built = threading.Event()
+
+        class SlowService(AlpaBridgeDriverService):
+            def _build_model(self) -> Any:
+                release.wait(5)
+                built.set()
+                return SimpleNamespace(name="slow-policy")
+
+        service = SlowService(model_name="route_following", defer_model_load=True)
+        try:
+            # The constructor must not have waited on the load.
+            assert service.wait_for_model(0) is False
+            assert built.is_set() is False
+        finally:
+            release.set()
+
+        assert service.wait_for_model(5) is True
+        assert service._require_model().name == "slow-policy"
+
+    def test_a_still_loading_policy_raises_rather_than_substituting_one(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ALPABRIDGE_DRIVER_MODEL_LOAD_TIMEOUT_S", "0.05")
+        service = AlpaBridgeDriverService.__new__(AlpaBridgeDriverService)
+        service.model_name = "slow"
+        service._model = None
+        service._model_error = None
+        service._model_ready = threading.Event()
+
+        with pytest.raises(TimeoutError, match="still loading"):
+            service._require_model()
+
+    def test_a_failed_load_surfaces_the_original_error(self) -> None:
+        service = AlpaBridgeDriverService.__new__(AlpaBridgeDriverService)
+        service.model_name = "broken"
+        service._model = None
+        service._model_error = ValueError("checkpoint missing")
+        service._model_ready = threading.Event()
+        service._model_ready.set()
+
+        with pytest.raises(ModelLoadError, match="checkpoint missing") as excinfo:
+            service._require_model()
+
+        # Distinct from a RuntimeError raised by a working policy, so the gRPC
+        # layer can report it as FAILED_PRECONDITION rather than a bad request.
+        assert isinstance(excinfo.value, RuntimeError)
+        assert isinstance(excinfo.value.__cause__, ValueError)
+
+    def test_a_background_load_failure_still_releases_waiters(self) -> None:
+        class BrokenService(AlpaBridgeDriverService):
+            def _build_model(self) -> Any:
+                raise ValueError("checkpoint missing")
+
+        service = BrokenService(model_name="route_following", defer_model_load=True)
+
+        assert service.wait_for_model(5) is True, "waiters must not hang on failure"
+        with pytest.raises(ModelLoadError):
+            service._require_model()


### PR DESCRIPTION
Load the policy off the serving critical path.

`AlpaBridgeDriverService` built its policy eagerly in `__init__`, before the gRPC port is bound, so a slow checkpoint load blocks readiness probes.

`defer_model_load` starts the load on a daemon thread and lets the caller bind and serve first; `main()` defers by default, with `ALPABRIDGE_DRIVER_EAGER_MODEL_LOAD=1` restoring eager loading for local debugging. Failures stay loud: a still-loading policy aborts `drive()` with `UNAVAILABLE`, and a failed load raises `ModelLoadError` mapped to `FAILED_PRECONDITION`, keeping a working policy's `RuntimeError` out of that branch. The wait inside `drive()` is bounded (`ALPABRIDGE_DRIVER_MODEL_LOAD_TIMEOUT_S`, default 30 s).

Tests cover the deferred constructor returning before the load completes, still-loading raising rather than substituting output, a failed load surfacing its original exception, and waiters being released on background failure.
