### PR TITLE
driver: make the MPC candidate sets reachable from the container

### DIFF
--- a/src/alpabridge/driver/policy_registry.py
+++ b/src/alpabridge/driver/policy_registry.py
@@ -136,11 +136,39 @@ def _build_route_following(adapter: PolicyContext) -> Any:
     return _baseline_factory(RouteFollowingAlpaSimModel)(adapter)
 
 
+def _env_float_tuple(name: str, default: tuple[float, ...]) -> tuple[float, ...]:
+    """Read a comma-separated float tuple override from the environment.
+
+    Candidate sets, unlike scalars, cannot be usefully clamped: an empty or
+    unparseable set would leave the planner with nothing to choose from, and
+    MPCPlannerConfig rejects that outright. So anything malformed warns and
+    falls back to the default rather than raising mid-rollout.
+    """
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        values = tuple(float(part) for part in raw.split(",") if part.strip())
+    except ValueError:
+        LOGGER.warning("%s=%r is not a comma-separated float list; using %s", name, raw, default)
+        return default
+    if not values:
+        LOGGER.warning("%s=%r parsed to an empty set; using %s", name, raw, default)
+        return default
+    return values
+
+
 def _build_mpc_planner(adapter: PolicyContext) -> Any:
     from alpabridge.simulator.mpc_planner import MPCPlannerAlpaSimModel, MPCPlannerConfig
 
     resample = _resample_config(adapter)
     defaults = MPCPlannerConfig()
+    accels_mps2 = _env_float_tuple(
+        "ALPABRIDGE_MPC_ACCELS_MPS2", defaults.accels_mps2
+    )
+    yaw_rates_rps = _env_float_tuple(
+        "ALPABRIDGE_MPC_YAW_RATES_RPS", defaults.yaw_rates_rps
+    )
     max_speed_mps = _env_float(
         "ALPABRIDGE_MPC_MAX_SPEED_MPS", defaults.max_speed_mps
     )
@@ -164,6 +192,8 @@ def _build_mpc_planner(adapter: PolicyContext) -> Any:
             point_count=resample.point_count,
             max_speed_mps=max_speed_mps,
             target_cruise_speed_mps=cruise_speed_mps,
+            accels_mps2=accels_mps2,
+            yaw_rates_rps=yaw_rates_rps,
         ),
     )
 

--- a/src/alpabridge/driver/policy_registry.py
+++ b/src/alpabridge/driver/policy_registry.py
@@ -29,6 +29,7 @@ class instead of copied - that duplication was accidental, this one isn't.
 from __future__ import annotations
 
 import logging
+import math
 import os
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -52,8 +53,13 @@ def _env_float(name: str, default: float) -> float:
     except ValueError:
         LOGGER.warning("%s=%r is not a number; using %s", name, raw, default)
         return default
-    if value <= 0:
-        LOGGER.warning("%s=%s must be positive; using %s", name, value, default)
+    # NaN fails every comparison, so `value <= 0` does not reject it and it would
+    # reach the planner and poison candidate rollouts silently. inf passes the
+    # positivity check for the same reason it is useless as a speed.
+    if not math.isfinite(value) or value <= 0:
+        LOGGER.warning(
+            "%s=%s must be a positive finite number; using %s", name, value, default
+        )
         return default
     return value
 
@@ -154,6 +160,13 @@ def _env_float_tuple(name: str, default: tuple[float, ...]) -> tuple[float, ...]
         return default
     if not values:
         LOGGER.warning("%s=%r parsed to an empty set; using %s", name, raw, default)
+        return default
+    # Candidate sets are allowed to contain zero and negatives — decelerations and
+    # left yaw rates are meaningful — so only finiteness is checked here.
+    if not all(math.isfinite(value) for value in values):
+        LOGGER.warning(
+            "%s=%r contains a non-finite value; using %s", name, raw, default
+        )
         return default
     return values
 

--- a/tests/test_policy_registry.py
+++ b/tests/test_policy_registry.py
@@ -4,6 +4,8 @@ import pytest
 
 from alpabridge.driver.policy_registry import (
     DriverPolicy,
+    _env_float,
+    _env_float_tuple,
     available_policy_names,
     build_policy,
     register_policy,
@@ -93,3 +95,64 @@ def test_build_policy_enforces_checkpoint_requirements_before_constructing() -> 
         from alpabridge.driver import policy_registry
 
         del policy_registry._REGISTRY["test_only_requires_both"]
+
+
+class TestEnvOverrides:
+    """The MPC tuning knobs are only reachable through the environment when the
+    driver runs behind gRPC, so the parsing has to be defensive: a typo in a
+    container env var must not take a driver down mid-evaluation, and must not
+    quietly reach the planner either."""
+
+    def test_scalar_override_is_applied(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ALPABRIDGE_TEST_SCALAR", "11.5")
+
+        assert _env_float("ALPABRIDGE_TEST_SCALAR", 8.0) == 11.5
+
+    def test_scalar_falls_back_when_unset_or_blank(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("ALPABRIDGE_TEST_SCALAR", raising=False)
+        assert _env_float("ALPABRIDGE_TEST_SCALAR", 8.0) == 8.0
+
+        monkeypatch.setenv("ALPABRIDGE_TEST_SCALAR", "   ")
+        assert _env_float("ALPABRIDGE_TEST_SCALAR", 8.0) == 8.0
+
+    @pytest.mark.parametrize("raw", ["junk", "-3", "0", "nan", "inf", "-inf"])
+    def test_scalar_rejects_unusable_values(
+        self, monkeypatch: pytest.MonkeyPatch, raw: str
+    ) -> None:
+        """nan is the subtle one: every comparison against it is False, so a
+        bare `value <= 0` guard lets it through to the planner."""
+        monkeypatch.setenv("ALPABRIDGE_TEST_SCALAR", raw)
+
+        assert _env_float("ALPABRIDGE_TEST_SCALAR", 8.0) == 8.0
+
+    def test_tuple_override_is_applied(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("ALPABRIDGE_TEST_TUPLE", "-4,-2,0,2,4,6")
+
+        assert _env_float_tuple("ALPABRIDGE_TEST_TUPLE", (1.0,)) == (
+            -4.0,
+            -2.0,
+            0.0,
+            2.0,
+            4.0,
+            6.0,
+        )
+
+    def test_tuple_keeps_zero_and_negative_candidates(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Decelerations and left yaw rates are meaningful, so unlike the scalar
+        knobs a candidate set must not be filtered for positivity."""
+        monkeypatch.setenv("ALPABRIDGE_TEST_TUPLE", "-2.5,0,1.5")
+
+        assert _env_float_tuple("ALPABRIDGE_TEST_TUPLE", (1.0,)) == (-2.5, 0.0, 1.5)
+
+    @pytest.mark.parametrize("raw", ["junk,2", " , , ", "", "1.0,nan", "2,inf"])
+    def test_tuple_rejects_unusable_sets(
+        self, monkeypatch: pytest.MonkeyPatch, raw: str
+    ) -> None:
+        default = (-2.5, -1.0, 0.0, 1.0, 1.5)
+        monkeypatch.setenv("ALPABRIDGE_TEST_TUPLE", raw)
+
+        assert _env_float_tuple("ALPABRIDGE_TEST_TUPLE", default) == default


### PR DESCRIPTION
Expose the MPC planner's candidate sets to the standalone driver.

#8 exposed the scalar speed targets but not the candidate sets they are pursued with. Adds `ALPABRIDGE_MPC_ACCELS_MPS2` and `ALPABRIDGE_MPC_YAW_RATES_RPS` as comma-separated env overrides.

Unlike the scalar knobs these cannot be clamped: an empty or unparseable set would leave `_select_candidate` with nothing to score, and `MPCPlannerConfig.__post_init__` rejects that — so malformed input warns and falls back to the defaults. Candidate sets legitimately contain zero and negative values, so only finiteness is checked.
