### PR TITLE
driver: announce the empty-frame fallback like the other two

### DIFF
--- a/src/alpabridge/driver/driver_service.py
+++ b/src/alpabridge/driver/driver_service.py
@@ -736,6 +736,14 @@ def _warn_once(key: str, message: str) -> None:
 
 def _image_array_from_bytes(image_bytes: bytes) -> np.ndarray:
     if not image_bytes:
+        # The third degradation in this function, and the only one that stayed
+        # silent: a policy reading pixels cannot tell this placeholder from a
+        # decoded frame except by shape.
+        _warn_once(
+            "image-bytes-empty",
+            "A camera frame arrived with no image bytes; passing a placeholder array "
+            "instead. Further empty frames are not logged.",
+        )
         return np.zeros((1,), dtype=np.uint8)
 
     try:

--- a/tests/test_image_fallbacks.py
+++ b/tests/test_image_fallbacks.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from alpabridge.driver.driver_service import (
+    _FALLBACK_WARNINGS,
+    _image_array_from_bytes,
+)
+
+
+def test_empty_camera_frame_announces_itself_once(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An empty frame degrades like a decode failure, so it should say so too."""
+    _FALLBACK_WARNINGS.discard("image-bytes-empty")
+    with caplog.at_level(logging.WARNING):
+        first = _image_array_from_bytes(b"")
+        second = _image_array_from_bytes(b"")
+
+    assert first.shape == (1,)
+    assert second.shape == (1,)
+    warnings = [r for r in caplog.records if "no image bytes" in r.getMessage()]
+    assert len(warnings) == 1


### PR DESCRIPTION
## The gap

`_image_array_from_bytes` has three degradation paths. Two of them announce
themselves after #7: Pillow missing, and a frame that fails to decode. The
third does not — a frame that arrives with no image bytes returns

```python
np.zeros((1,), dtype=np.uint8)
```

with nothing written to the log.

## Why it matters

That placeholder is a 1-D array, exactly like the two paths that now warn. A
policy reading pixels cannot tell it from a decoded frame except by inspecting
shape, so an empty frame silently changes what the policy sees for as long as
it keeps arriving. #7's argument applies unchanged; the path was simply missed.

## Change

Warn once through the existing `_warn_once` mechanism, keyed separately so it
does not suppress the decode-failure warning. The return value is untouched, so
no caller behaviour changes.

Test asserts the placeholder shape is preserved and that a second empty frame
does not log again.
