### PR TITLE
driver: keep the camera calibration and scale it to the delivered frame

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,9 @@ classifiers = [
 [project.optional-dependencies]
 dev = [
     "build>=1.0",
+    # The decode path and anything testing it need a decoder; without this the
+    # conformance tier silently skips every pixel-facing test.
+    "Pillow>=10",
     "pre-commit>=3.7",
     "pytest>=7.4",
     "pytest-cov>=5.0",

--- a/src/alpabridge/driver/camera_calibration.py
+++ b/src/alpabridge/driver/camera_calibration.py
@@ -1,0 +1,148 @@
+"""Per-camera calibration carried from `start_session` to the policy.
+
+AlpaSim hands the driver a calibration for every camera on the rig, and the
+challenge contract is explicit that it must be used rather than hard-coded: the
+supplied resolution describes the native camera and can differ from the JPEG
+that actually arrives, so intrinsics have to be scaled to the delivered image
+before any pixel-space calculation.
+
+Nothing in the driver did that - the calibration was dropped on arrival - so a
+policy reading pixels had to invent its own constants. This module keeps the
+calibration and does the one transformation the contract requires.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, replace
+from typing import Any
+
+LOGGER = logging.getLogger("alpabridge_camera_calibration")
+
+_PARAM_FIELDS = {
+    "ftheta_param": "ftheta",
+    "opencv_pinhole_param": "opencv_pinhole",
+    "opencv_fisheye_param": "opencv_fisheye",
+}
+
+
+@dataclass(frozen=True)
+class CameraCalibration:
+    """Intrinsics for one camera, valid for `width` x `height` pixels.
+
+    `width`/`height` are whatever the calibration currently describes: the
+    declared resolution as received, or the delivered one after `scaled_to`.
+    """
+
+    logical_id: str
+    width: int
+    height: int
+    model: str
+    principal_point_x: float
+    principal_point_y: float
+    focal_length_x: float | None = None
+    focal_length_y: float | None = None
+
+    def scaled_to(self, width: int, height: int) -> "CameraCalibration":
+        """Return this calibration expressed for a `width` x `height` image.
+
+        Principal point and focal lengths are the terms that live in pixels, so
+        they scale with the axis they belong to. Distortion coefficients are
+        dimensionless and are deliberately not carried here.
+        """
+        if width <= 0 or height <= 0:
+            raise ValueError(f"cannot scale calibration to {width}x{height}")
+        if self.width <= 0 or self.height <= 0:
+            raise ValueError(
+                f"calibration for {self.logical_id} declares an unusable "
+                f"resolution {self.width}x{self.height}"
+            )
+        if (width, height) == (self.width, self.height):
+            return self
+        scale_x = width / self.width
+        scale_y = height / self.height
+        return replace(
+            self,
+            width=width,
+            height=height,
+            principal_point_x=self.principal_point_x * scale_x,
+            principal_point_y=self.principal_point_y * scale_y,
+            focal_length_x=(None if self.focal_length_x is None else self.focal_length_x * scale_x),
+            focal_length_y=(None if self.focal_length_y is None else self.focal_length_y * scale_y),
+        )
+
+
+def _active_param(spec: Any) -> tuple[str, Any] | None:
+    """Pick the populated entry of CameraSpec's `camera_param` oneof."""
+    which = getattr(spec, "WhichOneof", None)
+    if callable(which):
+        field = which("camera_param")
+        if field in _PARAM_FIELDS:
+            return _PARAM_FIELDS[field], getattr(spec, field)
+        return None
+    # Test doubles carry a single attribute rather than a real oneof.
+    for field, model in _PARAM_FIELDS.items():
+        param = getattr(spec, field, None)
+        if param is not None:
+            return model, param
+    return None
+
+
+def calibration_from_available_camera(camera: Any) -> CameraCalibration | None:
+    """Build a calibration from one `AvailableCamerasReturn.AvailableCamera`.
+
+    Returns None when the message carries nothing usable, so a partial rig does
+    not deny the policy the cameras that are fine.
+    """
+    spec = getattr(camera, "intrinsics", None)
+    if spec is None:
+        return None
+    logical_id = str(getattr(spec, "logical_id", "") or getattr(camera, "logical_id", ""))
+    if not logical_id:
+        return None
+    active = _active_param(spec)
+    if active is None:
+        LOGGER.warning("camera %s carries no recognised intrinsics model", logical_id)
+        return None
+    model, param = active
+    width = int(getattr(spec, "resolution_w", 0) or 0)
+    height = int(getattr(spec, "resolution_h", 0) or 0)
+    if width <= 0 or height <= 0:
+        LOGGER.warning(
+            "camera %s declares resolution %sx%s; calibration cannot be scaled",
+            logical_id,
+            width,
+            height,
+        )
+        return None
+    focal_x = getattr(param, "focal_length_x", None)
+    focal_y = getattr(param, "focal_length_y", None)
+    return CameraCalibration(
+        logical_id=logical_id,
+        width=width,
+        height=height,
+        model=model,
+        principal_point_x=float(getattr(param, "principal_point_x", 0.0) or 0.0),
+        principal_point_y=float(getattr(param, "principal_point_y", 0.0) or 0.0),
+        focal_length_x=None if focal_x is None else float(focal_x),
+        focal_length_y=None if focal_y is None else float(focal_y),
+    )
+
+
+def calibrations_from_session_request(request: Any) -> dict[str, CameraCalibration]:
+    """Collect every usable calibration from a `DriveSessionRequest`.
+
+    An empty result is normal for the local baselines, which are served without
+    a rollout spec; it is the pixel-reading policies that care.
+    """
+    spec = getattr(request, "rollout_spec", None)
+    vehicle = getattr(spec, "vehicle", None) if spec is not None else None
+    cameras = getattr(vehicle, "available_cameras", None) if vehicle is not None else None
+    if not cameras:
+        return {}
+    calibrations: dict[str, CameraCalibration] = {}
+    for camera in cameras:
+        calibration = calibration_from_available_camera(camera)
+        if calibration is not None:
+            calibrations[calibration.logical_id] = calibration
+    return calibrations

--- a/src/alpabridge/driver/driver_service.py
+++ b/src/alpabridge/driver/driver_service.py
@@ -17,6 +17,10 @@ from typing import Any
 
 import numpy as np
 
+from alpabridge.driver.camera_calibration import (
+    CameraCalibration,
+    calibrations_from_session_request,
+)
 from alpabridge.driver.policy_registry import available_policy_names, build_policy
 from alpabridge.simulator.alpasim_contract import (
     DriveCommand,
@@ -50,6 +54,8 @@ class DriverSessionState:
     random_seed: int = 0
     debug_scene_id: str | None = None
     camera_images: dict[str, list[DriverCameraFrame]] = field(default_factory=dict)
+    camera_calibrations: dict[str, CameraCalibration] = field(default_factory=dict)
+    delivered_image_size: dict[str, tuple[int, int]] = field(default_factory=dict)
     ego_pose_history: list[Any] = field(default_factory=list)
     dynamic_states: list[tuple[int, Any]] = field(default_factory=list)
     route_waypoints: list[dict[str, float]] = field(default_factory=list)
@@ -227,11 +233,21 @@ class AlpaBridgeDriverService:
         session_uuid = str(request.session_uuid)
         debug_info = getattr(request, "debug_info", None)
         debug_scene_id = getattr(debug_info, "scene_id", None) if debug_info is not None else None
+        calibrations = calibrations_from_session_request(request)
+        if not calibrations:
+            # Only pixel-reading policies need this, so it is a warning and not a
+            # refusal; the geometric baselines run fine without a rig.
+            _warn_once(
+                "camera-calibration-absent",
+                "This session carried no usable camera calibration, so policies "
+                "reading pixels have no intrinsics to work from.",
+            )
         with self._lock:
             self._sessions[session_uuid] = DriverSessionState(
                 session_uuid=session_uuid,
                 random_seed=int(getattr(request, "random_seed", 0) or 0),
                 debug_scene_id=str(debug_scene_id) if debug_scene_id else None,
+                camera_calibrations=calibrations,
             )
         self._telemetry.record(
             {
@@ -258,10 +274,13 @@ class AlpaBridgeDriverService:
             timestamp_us=int(getattr(grpc_image, "frame_end_us", 0) or 0),
             image=_image_array_from_bytes(getattr(grpc_image, "image_bytes", b"")),
         )
+        delivered = _delivered_image_size(frame.image)
         with self._lock:
             frames = session.camera_images.setdefault(camera_id, [])
             frames.append(frame)
             del frames[:-1]
+            if delivered is not None:
+                session.delivered_image_size[camera_id] = delivered
         self._telemetry.record(
             {
                 "event": "image",
@@ -389,6 +408,9 @@ class AlpaBridgeDriverService:
             command = session.command
             random_seed = session.random_seed
             debug_scene_id = session.debug_scene_id
+            camera_calibrations = _calibrations_for_delivered_images(
+                session.camera_calibrations, session.delivered_image_size
+            )
         if self.route_contract_mode == "command_only_route":
             route_waypoints = []
         speed, velocity_xy, acceleration_xy = _estimate_ego_kinematics(
@@ -398,6 +420,7 @@ class AlpaBridgeDriverService:
 
         return SimpleNamespace(
             camera_images=camera_images,
+            camera_calibrations=camera_calibrations,
             command=command,
             speed=speed,
             acceleration=float(math.hypot(*acceleration_xy)),
@@ -841,6 +864,41 @@ def _image_array_from_bytes(image_bytes: bytes) -> np.ndarray:
             "Further decode failures are not logged.",
         )
         return np.frombuffer(image_bytes, dtype=np.uint8)
+
+
+def _delivered_image_size(image: np.ndarray) -> tuple[int, int] | None:
+    """(width, height) of a decoded frame, or None for the 1-D fallbacks."""
+    if image.ndim < 2:
+        return None
+    return int(image.shape[1]), int(image.shape[0])
+
+
+def _calibrations_for_delivered_images(
+    calibrations: dict[str, CameraCalibration],
+    delivered: dict[str, tuple[int, int]],
+) -> dict[str, CameraCalibration]:
+    """Express each calibration for the image size that actually arrived.
+
+    The declared resolution is the native camera's; the challenge rig delivers
+    JPEGs whose width can differ per scene, and intrinsics are only meaningful
+    against the image they are applied to.
+    """
+    scaled: dict[str, CameraCalibration] = {}
+    for camera_id, calibration in calibrations.items():
+        size = delivered.get(camera_id)
+        if size is None:
+            scaled[camera_id] = calibration
+            continue
+        try:
+            scaled[camera_id] = calibration.scaled_to(*size)
+        except ValueError:
+            _warn_once(
+                f"calibration-scale-failed-{camera_id}",
+                f"Could not scale the calibration for {camera_id} to the delivered "
+                f"{size[0]}x{size[1]} image; passing it through unscaled.",
+            )
+            scaled[camera_id] = calibration
+    return scaled
 
 
 def _pose_origin_and_yaw(pose_at_time: Any | None) -> tuple[float, float, float, float]:

--- a/tests/test_camera_calibration.py
+++ b/tests/test_camera_calibration.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import io
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from alpabridge.driver.camera_calibration import (
+    CameraCalibration,
+    calibration_from_available_camera,
+    calibrations_from_session_request,
+)
+from alpabridge.driver.driver_service import AlpaBridgeDriverService
+
+
+def _pinhole_camera(
+    logical_id: str = "camera_front_wide_120fov",
+    *,
+    width: int = 1920,
+    height: int = 1080,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        logical_id=logical_id,
+        intrinsics=SimpleNamespace(
+            logical_id=logical_id,
+            resolution_w=width,
+            resolution_h=height,
+            opencv_pinhole_param=SimpleNamespace(
+                principal_point_x=960.0,
+                principal_point_y=540.0,
+                focal_length_x=1545.0,
+                focal_length_y=1545.0,
+            ),
+        ),
+    )
+
+
+def _ftheta_camera(logical_id: str = "camera_cross_left_120fov") -> SimpleNamespace:
+    return SimpleNamespace(
+        logical_id=logical_id,
+        intrinsics=SimpleNamespace(
+            logical_id=logical_id,
+            resolution_w=1920,
+            resolution_h=1080,
+            ftheta_param=SimpleNamespace(
+                principal_point_x=958.0,
+                principal_point_y=542.0,
+            ),
+        ),
+    )
+
+
+def test_pinhole_intrinsics_are_read_from_the_camera_spec() -> None:
+    calibration = calibration_from_available_camera(_pinhole_camera())
+
+    assert calibration is not None
+    assert calibration.model == "opencv_pinhole"
+    assert calibration.width == 1920
+    assert calibration.height == 1080
+    assert calibration.principal_point_x == 960.0
+    assert calibration.focal_length_x == 1545.0
+
+
+def test_ftheta_intrinsics_are_read_without_a_focal_length() -> None:
+    calibration = calibration_from_available_camera(_ftheta_camera())
+
+    assert calibration is not None
+    assert calibration.model == "ftheta"
+    assert calibration.principal_point_y == 542.0
+    assert calibration.focal_length_x is None
+
+
+def test_scaling_moves_the_pixel_terms_and_leaves_the_rest() -> None:
+    calibration = calibration_from_available_camera(_pinhole_camera())
+    assert calibration is not None
+
+    # The official set delivers 1916x1080 on some scenes: width scales, height
+    # does not, so the two axes must be treated separately.
+    scaled = calibration.scaled_to(1916, 1080)
+
+    assert scaled.width == 1916
+    assert scaled.height == 1080
+    assert scaled.principal_point_x == pytest.approx(960.0 * 1916 / 1920)
+    assert scaled.principal_point_y == 540.0
+    assert scaled.focal_length_x == pytest.approx(1545.0 * 1916 / 1920)
+    assert scaled.focal_length_y == 1545.0
+    assert scaled.model == calibration.model
+
+
+def test_scaling_to_the_declared_size_is_the_same_object() -> None:
+    calibration = calibration_from_available_camera(_pinhole_camera())
+    assert calibration is not None
+
+    assert calibration.scaled_to(1920, 1080) is calibration
+
+
+@pytest.mark.parametrize("size", [(0, 1080), (1920, 0), (-1, 100)])
+def test_scaling_rejects_an_unusable_target_size(size: tuple[int, int]) -> None:
+    calibration = calibration_from_available_camera(_pinhole_camera())
+    assert calibration is not None
+
+    with pytest.raises(ValueError):
+        calibration.scaled_to(*size)
+
+
+def test_a_camera_without_a_declared_resolution_is_skipped() -> None:
+    camera = _pinhole_camera(width=0, height=0)
+
+    assert calibration_from_available_camera(camera) is None
+
+
+def test_a_camera_without_a_known_model_is_skipped() -> None:
+    camera = SimpleNamespace(
+        logical_id="camera_front_tele_30fov",
+        intrinsics=SimpleNamespace(
+            logical_id="camera_front_tele_30fov",
+            resolution_w=1920,
+            resolution_h=1080,
+        ),
+    )
+
+    assert calibration_from_available_camera(camera) is None
+
+
+def test_session_request_yields_one_calibration_per_usable_camera() -> None:
+    request = SimpleNamespace(
+        rollout_spec=SimpleNamespace(
+            vehicle=SimpleNamespace(
+                available_cameras=[
+                    _pinhole_camera(),
+                    _ftheta_camera(),
+                    _pinhole_camera("camera_broken", width=0, height=0),
+                ]
+            )
+        )
+    )
+
+    calibrations = calibrations_from_session_request(request)
+
+    assert set(calibrations) == {
+        "camera_front_wide_120fov",
+        "camera_cross_left_120fov",
+    }
+    assert isinstance(calibrations["camera_front_wide_120fov"], CameraCalibration)
+
+
+def test_a_session_without_a_rollout_spec_yields_nothing() -> None:
+    assert calibrations_from_session_request(SimpleNamespace()) == {}
+
+
+def _jpeg_bytes(width: int, height: int) -> bytes:
+    buffer = io.BytesIO()
+    Image.fromarray(np.zeros((height, width, 3), dtype=np.uint8)).save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+def test_the_policy_receives_intrinsics_scaled_to_the_delivered_frame() -> None:
+    """The declared resolution is the native camera's, not what arrives."""
+    camera_id = "camera_front_wide_120fov"
+    adapter = AlpaBridgeDriverService(model_name="route_following", camera_ids=(camera_id,))
+    adapter.start_session(
+        SimpleNamespace(
+            session_uuid="session-calib",
+            random_seed=1,
+            rollout_spec=SimpleNamespace(
+                vehicle=SimpleNamespace(available_cameras=[_pinhole_camera(camera_id)])
+            ),
+        )
+    )
+    adapter.submit_image_observation(
+        SimpleNamespace(
+            session_uuid="session-calib",
+            camera_image=SimpleNamespace(
+                logical_id=camera_id,
+                frame_end_us=1_000_000,
+                image_bytes=_jpeg_bytes(1916, 1080),
+            ),
+        )
+    )
+
+    calibrations = adapter.prediction_input(
+        "session-calib", time_now_us=1_000_000
+    ).camera_calibrations
+
+    assert set(calibrations) == {camera_id}
+    scaled = calibrations[camera_id]
+    assert (scaled.width, scaled.height) == (1916, 1080)
+    assert scaled.principal_point_x == pytest.approx(960.0 * 1916 / 1920)
+    assert scaled.focal_length_x == pytest.approx(1545.0 * 1916 / 1920)
+
+
+def test_calibration_survives_a_frame_that_cannot_be_decoded() -> None:
+    """A fallback frame has no dimensions, so the declared ones stand."""
+    camera_id = "camera_front_wide_120fov"
+    adapter = AlpaBridgeDriverService(model_name="route_following", camera_ids=(camera_id,))
+    adapter.start_session(
+        SimpleNamespace(
+            session_uuid="session-undecodable",
+            random_seed=1,
+            rollout_spec=SimpleNamespace(
+                vehicle=SimpleNamespace(available_cameras=[_pinhole_camera(camera_id)])
+            ),
+        )
+    )
+    adapter.submit_image_observation(
+        SimpleNamespace(
+            session_uuid="session-undecodable",
+            camera_image=SimpleNamespace(
+                logical_id=camera_id, frame_end_us=1_000_000, image_bytes=b"\x80"
+            ),
+        )
+    )
+
+    calibrations = adapter.prediction_input(
+        "session-undecodable", time_now_us=1_000_000
+    ).camera_calibrations
+
+    assert (calibrations[camera_id].width, calibrations[camera_id].height) == (
+        1920,
+        1080,
+    )
+
+
+def test_a_session_without_a_rig_still_serves() -> None:
+    adapter = AlpaBridgeDriverService(model_name="route_following", camera_ids=("front",))
+    adapter.start_session(SimpleNamespace(session_uuid="session-bare", random_seed=1))
+
+    assert adapter.prediction_input("session-bare", time_now_us=1).camera_calibrations == {}

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,7 @@ alpasim = [
 ]
 dev = [
     { name = "build" },
+    { name = "pillow" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -45,6 +46,7 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'alpasim'", specifier = ">=0.30" },
     { name = "matplotlib", marker = "extra == 'viz'", specifier = ">=3.8" },
     { name = "numpy", specifier = ">=1.26" },
+    { name = "pillow", marker = "extra == 'dev'", specifier = ">=10" },
     { name = "pillow", marker = "extra == 'driver'", specifier = ">=10" },
     { name = "pillow", marker = "extra == 'viz'", specifier = ">=10" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },


### PR DESCRIPTION
## What was missing

`start_session` carries a calibration for every camera on the rig, under
`rollout_spec.vehicle.available_cameras`. The driver read one field from it —
`logical_id` — and discarded the rest, so a policy that reads pixels had no
intrinsics available and would have to hard-code them.

## Why the declared resolution is not enough

`CameraSpec.resolution_w/h` describes the native camera, not the image that
arrives. The two can differ, and intrinsics are only meaningful against the
image they are applied to.

## Change

- `camera_calibration.py`: a `CameraCalibration` value with `scaled_to`, plus
  parsers for the `AvailableCamera` message, handling the `camera_param` oneof
  for ftheta, pinhole and fisheye.
- The session stores the rig's calibration at `start_session` and the delivered
  size per camera as frames arrive, taken from the decoded array rather than
  from anything declared.
- `prediction_input` exposes `camera_calibrations` already expressed for the
  delivered image.

Principal point and focal lengths scale per axis; distortion coefficients are
dimensionless and are deliberately not carried. A camera with no resolution or
no recognised model is skipped rather than guessed at, so one bad entry does
not cost the rest of the rig. A session without a rig warns once and behaves
exactly as before.

## Verified

394 passed, 1 skipped (380 before). 14 new tests cover both intrinsics models,
per-axis scaling, the undecodable-frame path where declared dimensions must
stand, skipping unusable cameras, and a rig-less session.
