### PR TITLE
driver: pair a frame with its calibration, and say when the optics disagree

### DIFF
--- a/src/alpabridge/driver/driver_service.py
+++ b/src/alpabridge/driver/driver_service.py
@@ -46,6 +46,9 @@ class ModelLoadError(RuntimeError):
 class DriverCameraFrame:
     timestamp_us: int
     image: np.ndarray
+    # The rig camera this frame came from. Policies receive frames under a
+    # single key, so this is the only way back to the matching calibration.
+    source_camera_id: str = ""
 
 
 @dataclass
@@ -273,6 +276,7 @@ class AlpaBridgeDriverService:
         frame = DriverCameraFrame(
             timestamp_us=int(getattr(grpc_image, "frame_end_us", 0) or 0),
             image=_image_array_from_bytes(getattr(grpc_image, "image_bytes", b"")),
+            source_camera_id=camera_id,
         )
         delivered = _delivered_image_size(frame.image)
         with self._lock:

--- a/src/alpabridge/simulator/vavam_model.py
+++ b/src/alpabridge/simulator/vavam_model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import platform
 from collections import OrderedDict
 from contextlib import nullcontext
@@ -51,11 +52,58 @@ def vavam_command_id(command: Any) -> int:
     return _COMMAND_TO_VAVAM_ID.get(index, _COMMAND_TO_VAVAM_ID[int(DriveCommand.UNKNOWN)])
 
 
+LOGGER = logging.getLogger("alpabridge_vavam")
+
+# Half of the tightest crop this model takes; beyond it, centre-cropping starts
+# discarding what the optical centre is looking at.
+_OPTICAL_CENTRE_WARN_PX = 50.0
+_CENTRE_WARNINGS: set[str] = set()
+
+
+def _warn_once(key: str, message: str) -> None:
+    if key not in _CENTRE_WARNINGS:
+        _CENTRE_WARNINGS.add(key)
+        LOGGER.warning(message)
+
+
 def latest_camera_image(camera_images: dict[str, list[Any]], camera_id: str) -> np.ndarray:
     frames = camera_images.get(camera_id) or []
     if not frames:
         raise ValueError(f"no camera frames available for {camera_id!r}")
     return np.asarray(frames[-1].image)
+
+
+def _check_optical_centre(
+    prediction_input: Any, camera_images: dict[str, list[Any]], camera_id: str
+) -> float | None:
+    """Report how far this camera's optical centre sits from the frame centre.
+
+    VAVAM was trained on rectified, near-centred pinhole frames, and this
+    adapter feeds it whatever the rig delivers. Where the two disagree the
+    model is out of distribution, and nothing downstream would say so.
+
+    Frames reach a policy under a single key regardless of which rig camera
+    produced them, so the frame's own `source_camera_id` is what pairs it with
+    a calibration. Returns the offset in pixels, or None when unknown.
+    """
+    frames = camera_images.get(camera_id) or []
+    if not frames:
+        return None
+    calibrations = getattr(prediction_input, "camera_calibrations", None) or {}
+    source_id = getattr(frames[-1], "source_camera_id", "")
+    calibration = calibrations.get(source_id) if source_id else None
+    if calibration is None:
+        return None
+    offset = abs(calibration.principal_point_y - calibration.height / 2.0)
+    if offset > _OPTICAL_CENTRE_WARN_PX:
+        _warn_once(
+            f"optical-centre-offset-{source_id}",
+            f"{source_id} places its optical centre {offset:.0f} px from the frame "
+            "centre, and this adapter does not rectify. The horizon therefore sits "
+            "away from where a pinhole-trained model expects it; cropping cannot "
+            "correct this, only rectification can.",
+        )
+    return offset
 
 
 class VAVAMAlpaSimModel(BaseTrajectoryModel):
@@ -173,6 +221,9 @@ class VAVAMAlpaSimModel(BaseTrajectoryModel):
         def _infer() -> np.ndarray:
             command_id = self._encode_command(prediction_input.command)
             image = latest_camera_image(prediction_input.camera_images, self.camera_ids[0])
+            _check_optical_centre(
+                prediction_input, prediction_input.camera_images, self.camera_ids[0]
+            )
             return self._run_inference(image, command_id)
 
         native_trajectory_xy, reused_cache = self._inference_cache.get(prediction_input, _infer)

--- a/tests/test_optical_centre_diagnostic.py
+++ b/tests/test_optical_centre_diagnostic.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from alpabridge.simulator.vavam_model import _check_optical_centre
+
+
+def _calibration(principal_point_y: float) -> SimpleNamespace:
+    return SimpleNamespace(
+        principal_point_x=957.5,
+        principal_point_y=principal_point_y,
+        width=1920,
+        height=1080,
+    )
+
+
+def _prediction_input(source_camera_id: str, calibrations: dict) -> SimpleNamespace:
+    frame = SimpleNamespace(image=None, source_camera_id=source_camera_id)
+    return SimpleNamespace(camera_images={"front": [frame]}, camera_calibrations=calibrations)
+
+
+def test_the_offset_is_measured_through_the_frame_source_camera() -> None:
+    camera_id = "camera_front_wide_120fov"
+    prediction_input = _prediction_input(camera_id, {camera_id: _calibration(743.2)})
+
+    offset = _check_optical_centre(prediction_input, prediction_input.camera_images, "front")
+
+    assert offset == pytest.approx(203.2)
+
+
+def test_a_centred_camera_reports_a_small_offset() -> None:
+    camera_id = "camera_front_tele_30fov"
+    prediction_input = _prediction_input(camera_id, {camera_id: _calibration(540.0)})
+
+    assert _check_optical_centre(
+        prediction_input, prediction_input.camera_images, "front"
+    ) == pytest.approx(0.0)
+
+
+def test_a_frame_whose_camera_is_not_in_the_rig_reports_nothing() -> None:
+    prediction_input = _prediction_input(
+        "camera_not_in_the_rig", {"camera_front_wide_120fov": _calibration(743.2)}
+    )
+
+    assert _check_optical_centre(prediction_input, prediction_input.camera_images, "front") is None
+
+
+def test_a_session_without_calibration_reports_nothing() -> None:
+    frame = SimpleNamespace(image=None, source_camera_id="camera_front_wide_120fov")
+    prediction_input = SimpleNamespace(camera_images={"front": [frame]})
+
+    assert _check_optical_centre(prediction_input, prediction_input.camera_images, "front") is None
+
+
+def test_no_frames_reports_nothing() -> None:
+    prediction_input = SimpleNamespace(camera_images={}, camera_calibrations={})
+
+    assert _check_optical_centre(prediction_input, prediction_input.camera_images, "front") is None
+
+
+@pytest.mark.parametrize(("principal_point_y", "expect_warning"), [(743.2, True), (545.0, False)])
+def test_a_far_optical_centre_says_so_once(
+    caplog: pytest.LogCaptureFixture, principal_point_y: float, expect_warning: bool
+) -> None:
+    from alpabridge.simulator import vavam_model
+
+    camera_id = f"camera_probe_{principal_point_y}"
+    vavam_model._CENTRE_WARNINGS.discard(f"optical-centre-offset-{camera_id}")
+    prediction_input = _prediction_input(camera_id, {camera_id: _calibration(principal_point_y)})
+
+    with caplog.at_level("WARNING"):
+        _check_optical_centre(prediction_input, prediction_input.camera_images, "front")
+        _check_optical_centre(prediction_input, prediction_input.camera_images, "front")
+
+    warnings = [r for r in caplog.records if "optical centre" in r.getMessage()]
+    assert len(warnings) == (1 if expect_warning else 0)
+    if expect_warning:
+        assert "only rectification can" in warnings[0].getMessage()


### PR DESCRIPTION
Follow-up to #12, which stored the calibration but left two gaps.

## A policy could not reach it

`prediction_input.camera_calibrations` is keyed by the rig's logical id, but
frames arrive under a single key (`front`) no matter which camera produced
them, so there was no way to pair a frame with its calibration. Frames now
carry `source_camera_id`, which closes that.

## Nothing reported when the optics disagree

A model trained on rectified, roughly centred pinhole frames is out of
distribution when the camera's optical centre sits far from the frame centre,
and nothing in the adapter said so. It now warns once per camera when the
calibration reports a large offset.

Only a diagnostic: this reports the condition, it does not correct it.
Correcting it needs rectification, which is a separate change.

## Verified

401 passed, 1 skipped (394 before). Tests cover the offset measured through the
frame's source camera, a centred camera, an unknown camera and a rig-less
session reporting nothing, and the warning firing once above the threshold and
never below it.
