### PR TITLE
driver: adopt AlpaSim's f-theta rectification for the pinhole policies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ dev = [
     # The decode path and anything testing it need a decoder; without this the
     # conformance tier silently skips every pixel-facing test.
     "Pillow>=10",
+    # CI must actually exercise rectification rather than skip past it.
+    "opencv-python-headless>=4.10",
     "pre-commit>=3.7",
     "pytest>=7.4",
     "pytest-cov>=5.0",
@@ -52,6 +54,9 @@ alpasim = [
     "pyarrow>=16",
 ]
 viz = ["Pillow>=10", "matplotlib>=3.8"]
+# f-theta -> pinhole rectification. Optional: without it frames reach policies
+# as rendered, which is what happened before rectification existed.
+rectify = ["opencv-python-headless>=4.10"]
 # Serving the gRPC driver against a real simulator: every rollout streams JPEG
 # camera frames, which need a decoder.
 driver = ["Pillow>=10"]
@@ -124,6 +129,10 @@ fail_under = 33
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+# Vendored code stays byte-identical to upstream so it can be diffed when the
+# reference moves; linting or formatting it would defeat that. See
+# src/alpabridge/third_party/NOTICE.
+extend-exclude = ["src/alpabridge/third_party"]
 
 [tool.ruff.lint]
 select = ["F", "I"]

--- a/src/alpabridge/driver/camera_calibration.py
+++ b/src/alpabridge/driver/camera_calibration.py
@@ -129,6 +129,29 @@ def calibration_from_available_camera(camera: Any) -> CameraCalibration | None:
     )
 
 
+def camera_protos_from_session_request(request: Any) -> dict[str, Any]:
+    """Keep the raw `AvailableCamera` messages, keyed by logical id.
+
+    The parsed calibration is what a policy reasons with, but rectification is
+    built from the original message: it needs the f-theta polynomial, which
+    `CameraCalibration` deliberately does not carry.
+    """
+    spec = getattr(request, "rollout_spec", None)
+    vehicle = getattr(spec, "vehicle", None) if spec is not None else None
+    cameras = getattr(vehicle, "available_cameras", None) if vehicle is not None else None
+    if not cameras:
+        return {}
+    protos: dict[str, Any] = {}
+    for camera in cameras:
+        intrinsics = getattr(camera, "intrinsics", None)
+        logical_id = str(
+            getattr(intrinsics, "logical_id", "") or getattr(camera, "logical_id", "")
+        )
+        if logical_id:
+            protos[logical_id] = camera
+    return protos
+
+
 def calibrations_from_session_request(request: Any) -> dict[str, CameraCalibration]:
     """Collect every usable calibration from a `DriveSessionRequest`.
 

--- a/src/alpabridge/driver/driver_service.py
+++ b/src/alpabridge/driver/driver_service.py
@@ -20,6 +20,7 @@ import numpy as np
 from alpabridge.driver.camera_calibration import (
     CameraCalibration,
     calibrations_from_session_request,
+    camera_protos_from_session_request,
 )
 from alpabridge.driver.policy_registry import available_policy_names, build_policy
 from alpabridge.simulator.alpasim_contract import (
@@ -58,6 +59,7 @@ class DriverSessionState:
     debug_scene_id: str | None = None
     camera_images: dict[str, list[DriverCameraFrame]] = field(default_factory=dict)
     camera_calibrations: dict[str, CameraCalibration] = field(default_factory=dict)
+    camera_protos: dict[str, Any] = field(default_factory=dict)
     delivered_image_size: dict[str, tuple[int, int]] = field(default_factory=dict)
     ego_pose_history: list[Any] = field(default_factory=list)
     dynamic_states: list[tuple[int, Any]] = field(default_factory=list)
@@ -237,6 +239,7 @@ class AlpaBridgeDriverService:
         debug_info = getattr(request, "debug_info", None)
         debug_scene_id = getattr(debug_info, "scene_id", None) if debug_info is not None else None
         calibrations = calibrations_from_session_request(request)
+        camera_protos = camera_protos_from_session_request(request)
         if not calibrations:
             # Only pixel-reading policies need this, so it is a warning and not a
             # refusal; the geometric baselines run fine without a rig.
@@ -251,6 +254,7 @@ class AlpaBridgeDriverService:
                 random_seed=int(getattr(request, "random_seed", 0) or 0),
                 debug_scene_id=str(debug_scene_id) if debug_scene_id else None,
                 camera_calibrations=calibrations,
+                camera_protos=camera_protos,
             )
         self._telemetry.record(
             {
@@ -415,6 +419,7 @@ class AlpaBridgeDriverService:
             camera_calibrations = _calibrations_for_delivered_images(
                 session.camera_calibrations, session.delivered_image_size
             )
+            camera_protos = dict(session.camera_protos)
         if self.route_contract_mode == "command_only_route":
             route_waypoints = []
         speed, velocity_xy, acceleration_xy = _estimate_ego_kinematics(
@@ -425,6 +430,7 @@ class AlpaBridgeDriverService:
         return SimpleNamespace(
             camera_images=camera_images,
             camera_calibrations=camera_calibrations,
+            camera_protos=camera_protos,
             command=command,
             speed=speed,
             acceleration=float(math.hypot(*acceleration_xy)),

--- a/src/alpabridge/simulator/camera_rectification.py
+++ b/src/alpabridge/simulator/camera_rectification.py
@@ -1,0 +1,111 @@
+"""Rectify f-theta rig frames into the pinhole view a policy expects.
+
+The rig's 120 degree cameras are f-theta and place their optical centre about
+200 px below the frame centre; models like VAVAM were trained on rectified,
+roughly centred pinhole images. Feeding one the other is a silent domain gap
+that no amount of cropping fixes.
+
+The transform itself is AlpaSim's, vendored verbatim under
+`alpabridge/third_party/` so it matches the reference submission exactly. This
+module is the AlpaBridge side: when to build a rectifier, what to do when the
+optional dependencies are missing, and never failing a rollout over it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import numpy as np
+
+LOGGER = logging.getLogger("alpabridge_camera_rectification")
+
+_WARNED: set[str] = set()
+
+# The reference submission's NuScenes-style pinhole target. Reproduced from
+# `default_rectification_config()` in AlpaSim's sample_submission_vavam driver
+# so a rectified frame here matches a rectified frame there.
+_TARGET_FOCAL_LENGTH = (1545.0, 1545.0)
+_TARGET_PRINCIPAL_POINT = (960.0, 560.0)
+_TARGET_RESOLUTION_HW = (1080, 1920)
+_TARGET_RADIAL = (-0.356123, 0.172545, -0.05231, 0.0, 0.0, 0.0)
+_TARGET_TANGENTIAL = (-0.00213, 0.000464)
+_TARGET_THIN_PRISM = (0.0, 0.0, 0.0, 0.0)
+
+
+def _warn_once(key: str, message: str) -> None:
+    if key not in _WARNED:
+        _WARNED.add(key)
+        LOGGER.warning(message)
+
+
+def rectification_disabled() -> bool:
+    """True when the operator has opted out of rectification."""
+    raw = os.environ.get("ALPABRIDGE_DISABLE_RECTIFICATION", "0").strip().lower()
+    return raw in {"1", "true", "yes"}
+
+
+def default_target_config() -> Any:
+    """The pinhole target to rectify into, or None if the transform is absent."""
+    try:
+        from alpabridge.third_party.alpasim_rectification import (
+            RectificationTargetConfig,
+        )
+    except ImportError as exc:
+        _warn_once(
+            "rectification-unavailable",
+            "Camera rectification is unavailable, so f-theta frames reach policies "
+            f"as rendered: {exc}. Install alpabridge[rectify] for the decoder and "
+            "have alpasim_grpc importable.",
+        )
+        return None
+    return RectificationTargetConfig(
+        focal_length=_TARGET_FOCAL_LENGTH,
+        principal_point=_TARGET_PRINCIPAL_POINT,
+        resolution_hw=_TARGET_RESOLUTION_HW,
+        radial=_TARGET_RADIAL,
+        tangential=_TARGET_TANGENTIAL,
+        thin_prism=_TARGET_THIN_PRISM,
+    )
+
+
+def build_rectifier(camera_proto: Any, source_hw: tuple[int, int]) -> Any | None:
+    """Build a rectifier for one camera at the resolution actually delivered.
+
+    Returns None whenever rectification cannot be done, having said why once:
+    a rollout that runs unrectified is worse than one that runs, but a rollout
+    that dies on a missing optional dependency is worse than both.
+    """
+    if camera_proto is None:
+        return None
+    target = default_target_config()
+    if target is None:
+        return None
+    try:
+        from alpabridge.third_party.alpasim_rectification import (
+            build_ftheta_rectifier_for_resolution,
+        )
+
+        return build_ftheta_rectifier_for_resolution(camera_proto, target, source_hw)
+    except Exception as exc:  # noqa: BLE001 - reported, never fatal
+        _warn_once(
+            f"rectifier-build-failed-{source_hw}",
+            f"Could not build a rectifier for a {source_hw[1]}x{source_hw[0]} frame; "
+            f"passing it through unrectified: {exc!r}",
+        )
+        return None
+
+
+def rectify_image(rectifier: Any, image: np.ndarray) -> np.ndarray:
+    """Apply `rectifier`, falling back to the original frame on any failure."""
+    if rectifier is None:
+        return image
+    try:
+        return np.asarray(rectifier.rectify(image))
+    except Exception as exc:  # noqa: BLE001 - reported, never fatal
+        _warn_once(
+            "rectify-failed",
+            f"Rectifying a camera frame failed; using it as rendered: {exc!r}",
+        )
+        return image

--- a/src/alpabridge/simulator/vavam_model.py
+++ b/src/alpabridge/simulator/vavam_model.py
@@ -22,6 +22,7 @@ from .alpasim_contract import (
     make_model_prediction,
     resample_trajectory,
 )
+from .camera_rectification import build_rectifier, rectification_disabled, rectify_image
 from .image_ops import resize_and_center_crop
 from .inference_rate_cache import PoseReanchoredInferenceCache
 
@@ -167,6 +168,9 @@ class VAVAMAlpaSimModel(BaseTrajectoryModel):
         self._dtype = torch.float16 if self._use_autocast else torch.float32
         self._vam, self._tokenizer, self._transform = self._load()
         self._inference_cache = PoseReanchoredInferenceCache(min_interval_s=VAVAM_NATIVE_PERIOD_S)
+        # One rectifier per camera and delivered size; building one is expensive
+        # and the pair is fixed for a rollout.
+        self._rectifiers: dict[tuple[str, tuple[int, int]], Any] = {}
 
     @property
     def camera_ids(self) -> list[str]:
@@ -224,6 +228,7 @@ class VAVAMAlpaSimModel(BaseTrajectoryModel):
             _check_optical_centre(
                 prediction_input, prediction_input.camera_images, self.camera_ids[0]
             )
+            image = self._rectified(prediction_input, image)
             return self._run_inference(image, command_id)
 
         native_trajectory_xy, reused_cache = self._inference_cache.get(prediction_input, _infer)
@@ -260,6 +265,27 @@ class VAVAMAlpaSimModel(BaseTrajectoryModel):
             headings=headings,
             reasoning_text=json.dumps(metadata, sort_keys=True),
         )
+
+    def _rectified(self, prediction_input: Any, image: np.ndarray) -> np.ndarray:
+        """Rectify the frame into the pinhole view VAVAM was trained on.
+
+        VAVAM expects rectified, roughly centred pinhole images; the rig renders
+        f-theta. Rectifying is therefore the default, and every way it can fail
+        returns the frame as rendered - which is what this adapter did before
+        rectification existed, so a failure is never worse than not having it.
+        """
+        if image.ndim < 2 or rectification_disabled():
+            return image
+        frames = prediction_input.camera_images.get(self.camera_ids[0]) or []
+        source_id = getattr(frames[-1], "source_camera_id", "") if frames else ""
+        if not source_id:
+            return image
+        source_hw = (int(image.shape[0]), int(image.shape[1]))
+        key = (source_id, source_hw)
+        if key not in self._rectifiers:
+            protos = getattr(prediction_input, "camera_protos", None) or {}
+            self._rectifiers[key] = build_rectifier(protos.get(source_id), source_hw)
+        return rectify_image(self._rectifiers[key], image)
 
     def _run_inference(self, image: np.ndarray, command_id: int) -> np.ndarray:
         cropped = resize_and_center_crop(image, VAVAM_EXPECTED_HEIGHT, VAVAM_EXPECTED_WIDTH)

--- a/src/alpabridge/third_party/NOTICE
+++ b/src/alpabridge/third_party/NOTICE
@@ -1,0 +1,23 @@
+alpasim_rectification.py
+------------------------
+
+Vendored verbatim from NVlabs/alpasim, no modifications.
+
+  repository: https://github.com/NVlabs/alpasim
+  branch:     e2e_challenge
+  path:       e2e_challenge/sample_submission_vavam/vavam_challenge/rectification.py
+  commit:     d9bc5cf714 (2026-06-26)
+  sha256:     15e75cc900af5721... (of the file as vendored)
+
+Copyright (c) 2025-2026 NVIDIA Corporation, licensed Apache-2.0. The SPDX
+identifier and copyright line are retained in the file itself. AlpaBridge is
+BSD-3-Clause; this file keeps its own licence.
+
+Adopted rather than reimplemented so f-theta rectification matches the
+reference submission's behaviour exactly. Keeping it byte-identical means it
+can be diffed against upstream when the reference moves, which a rewrite could
+not offer. Any AlpaBridge-side behaviour lives in
+`alpabridge/simulator/camera_rectification.py`, never here.
+
+It imports `cv2` and `alpasim_grpc`, neither of which AlpaBridge requires: the
+wrapper imports this module lazily and degrades when they are absent.

--- a/src/alpabridge/third_party/__init__.py
+++ b/src/alpabridge/third_party/__init__.py
@@ -1,0 +1,1 @@
+"""Third-party code vendored verbatim. See NOTICE for origin and licences."""

--- a/src/alpabridge/third_party/alpasim_rectification.py
+++ b/src/alpabridge/third_party/alpasim_rectification.py
@@ -1,0 +1,546 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2025-2026 NVIDIA Corporation
+
+"""Module to rectify f-theta camera renders into pinhole frames.
+
+Note: NuRec renderer will support pinhole rendering natively in the future.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from typing import Tuple
+
+import cv2
+import numpy as np
+from alpasim_grpc.v0 import sensorsim_pb2
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class RectificationTargetConfig:
+    """Target pinhole parameters for rectifying the challenge front camera."""
+
+    focal_length: tuple[float, float]
+    principal_point: tuple[float, float]
+    resolution_hw: tuple[int, int]
+    radial: tuple[float, ...] = ()
+    tangential: tuple[float, ...] = ()
+    thin_prism: tuple[float, ...] = ()
+    max_overscan_scale: float = 2.0
+    safety_margin_px: int = 10
+
+
+def _has_distortion(config: RectificationTargetConfig) -> bool:
+    """Return True if any distortion coefficients are provided."""
+    return bool(config.radial or config.tangential or config.thin_prism)
+
+
+def _dist_coeff_vector(config: RectificationTargetConfig) -> np.ndarray:
+    """Return a 14-length OpenCV distortion vector from the config."""
+
+    dist = np.zeros(14, dtype=np.float64)
+    for idx, value in enumerate(config.radial[:6]):
+        dist[[0, 1, 4, 5, 6, 7][idx]] = value
+    for idx, value in enumerate(config.tangential[:2]):
+        dist[[2, 3][idx]] = value
+    for idx, value in enumerate(config.thin_prism[:4]):
+        dist[8 + idx] = value
+    return dist
+
+
+def _compute_overscan_scale(config: RectificationTargetConfig) -> float:
+    """Estimate overscan scale needed to keep undistorted points inside the frame.
+
+    The heuristic samples a small grid on the *distorted* canvas, undistorts the
+    samples, measures how far they would land outside the canvas, and converts
+    the maximal overflow into a uniform scale. Clamped by `max_overscan_scale`.
+
+    This is necessary because we first rectify from f-theta to a pinhole frame,
+    and then re-introduce distortions of the pinhole camera.
+    To not loose needed image content in the rectification step, we rectify
+    a larger canvas and only crop in the end.
+    """
+
+    if not _has_distortion(config):
+        return 1.0
+
+    height, width = config.resolution_hw
+    fx, fy = config.focal_length
+    cx, cy = config.principal_point
+    camera_matrix = np.array(
+        [[fx, 0.0, cx], [0.0, fy, cy], [0.0, 0.0, 1.0]], dtype=np.float64
+    )
+    dist = _dist_coeff_vector(config)
+
+    # Sample a moderately dense grid to avoid under-estimating overflow; cost is tiny
+    # (cv2.undistortPoints on <200 samples is negligible compared to map builds).
+    samples_x = np.linspace(0.0, width - 1.0, num=9, dtype=np.float64)
+    samples_y = np.linspace(0.0, height - 1.0, num=9, dtype=np.float64)
+    grid_x, grid_y = np.meshgrid(samples_x, samples_y)
+    distorted_pixels = np.stack((grid_x, grid_y), axis=-1)
+
+    undistorted = cv2.undistortPoints(
+        distorted_pixels.reshape(-1, 1, 2),
+        cameraMatrix=camera_matrix,
+        distCoeffs=dist,
+    ).reshape(-1, 2)
+    undistorted_pixels = np.empty_like(undistorted)
+    undistorted_pixels[:, 0] = undistorted[:, 0] * fx + cx
+    undistorted_pixels[:, 1] = undistorted[:, 1] * fy + cy
+
+    min_x = float(np.min(undistorted_pixels[:, 0]))
+    max_x = float(np.max(undistorted_pixels[:, 0]))
+    min_y = float(np.min(undistorted_pixels[:, 1]))
+    max_y = float(np.max(undistorted_pixels[:, 1]))
+
+    overflow_left = max(0.0, -min_x)
+    overflow_right = max(0.0, max_x - (width - 1))
+    overflow_top = max(0.0, -min_y)
+    overflow_bottom = max(0.0, max_y - (height - 1))
+
+    margin_x = max(overflow_left, overflow_right) + float(config.safety_margin_px)
+    margin_y = max(overflow_top, overflow_bottom) + float(config.safety_margin_px)
+
+    if margin_x <= 0.0 and margin_y <= 0.0:
+        return 1.0
+
+    scale_x = 1.0 + 2.0 * margin_x / float(width)
+    scale_y = 1.0 + 2.0 * margin_y / float(height)
+    overscan_scale = max(scale_x, scale_y)
+    overscan_scale = min(overscan_scale, float(config.max_overscan_scale))
+    overscan_scale = max(1.0, overscan_scale)
+    return overscan_scale
+
+
+class _PinholeCamera:
+    """Generates unit rays for every pixel in an image."""
+
+    def __init__(
+        self,
+        focal_length: Tuple[float, float],
+        principal_point: Tuple[float, float],
+        resolution_hw: Tuple[int, int],
+    ) -> None:
+        """Cache basic intrinsics for fast ray generation."""
+
+        self._fx, self._fy = focal_length
+        self._cx, self._cy = principal_point
+        self._height, self._width = resolution_hw
+
+    def unit_rays_grid(self) -> np.ndarray:
+        """Return a (H, W, 3) array of unit rays for each image pixel."""
+
+        xs = np.arange(self._width, dtype=np.float64)
+        ys = np.arange(self._height, dtype=np.float64)
+        grid_x, grid_y = np.meshgrid(xs, ys)
+        x = (grid_x - self._cx) / self._fx
+        y = (grid_y - self._cy) / self._fy
+        z = np.ones_like(x)
+        rays = np.stack((x, y, z), axis=-1)
+        norms = np.linalg.norm(rays, axis=-1, keepdims=True)
+        norms = np.clip(norms, a_min=1e-9, a_max=None)
+        return rays / norms
+
+
+class _FthetaCamera:
+    """Projects unit rays into pixel coordinates using theta→radius polynomials."""
+
+    def __init__(
+        self,
+        intrinsics: sensorsim_pb2.FthetaCameraParam,
+        resolution_hw: Tuple[int, int],
+    ) -> None:
+        """Precompute polynomial and linear transform state for projections."""
+
+        self._angle_to_pixeldist = np.asarray(
+            intrinsics.angle_to_pixeldist_poly, dtype=np.float64
+        )
+        self._pixeldist_to_angle = np.asarray(
+            intrinsics.pixeldist_to_angle_poly, dtype=np.float64
+        )
+        self._principal_point = np.array(
+            [intrinsics.principal_point_x, intrinsics.principal_point_y],
+            dtype=np.float64,
+        )
+        self._max_angle = intrinsics.max_angle
+        if intrinsics.HasField("linear_cde"):
+            linear_c = intrinsics.linear_cde.linear_c
+            linear_d = intrinsics.linear_cde.linear_d
+            linear_e = intrinsics.linear_cde.linear_e
+        else:
+            linear_c, linear_d, linear_e = 1.0, 0.0, 0.0
+        self._linear_matrix = np.array(
+            [[linear_c, linear_d], [linear_e, 1.0]],
+            dtype=np.float64,
+        )
+        self._source_resolution = resolution_hw
+
+    def ray_to_pixel(self, rays: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """Project rays (N,3) into pixel coordinates.
+
+        Returns both the pixel coordinates and a boolean validity mask.
+        """
+
+        reshaped = rays.reshape(-1, 3).astype(np.float64)
+        xy = reshaped[:, :2]
+        z = reshaped[:, 2]
+        xy_norm = np.linalg.norm(xy, axis=1)
+
+        theta = np.zeros_like(xy_norm)
+        positive_z = z > 0.0
+        theta[positive_z] = np.arctan2(xy_norm[positive_z], z[positive_z])
+        within_fov = theta <= self._max_angle + 1e-6
+
+        radii = np.polynomial.polynomial.polyval(theta, self._angle_to_pixeldist)
+        # Avoid division by zero for rays along the optical axis.
+        with np.errstate(divide="ignore", invalid="ignore"):
+            scales = np.divide(
+                radii, xy_norm, out=np.zeros_like(radii), where=xy_norm > 1e-9
+            )
+
+        offsets = xy * scales[:, None]
+        pixel_offsets = offsets @ self._linear_matrix.T
+        pixels = pixel_offsets + self._principal_point
+
+        height, width = self._source_resolution
+        in_image = (
+            (pixels[:, 0] >= -0.5)
+            & (pixels[:, 0] <= width - 0.5)
+            & (pixels[:, 1] >= -0.5)
+            & (pixels[:, 1] <= height - 0.5)
+        )
+        valid = positive_z & within_fov & in_image
+
+        return pixels.reshape(rays.shape[:-1] + (2,)), valid.reshape(rays.shape[:-1])
+
+
+class FthetaToPinholeRectifier:
+    """Caches cv2.remap grids to rectify f-theta renders into a pinhole view."""
+
+    def __init__(
+        self,
+        source_intrinsics: sensorsim_pb2.FthetaCameraParam,
+        source_resolution_hw: Tuple[int, int],
+        target_intrinsics: RectificationTargetConfig,
+    ) -> None:
+        """Precompute remap grids that turn f-theta pixels into pinhole pixels."""
+
+        self._source_resolution = tuple(int(v) for v in source_resolution_hw)
+        self._requested_resolution = tuple(
+            int(v) for v in target_intrinsics.resolution_hw
+        )
+
+        self._overscan_scale = _compute_overscan_scale(target_intrinsics)
+        requested_h, requested_w = self._requested_resolution
+        if self._overscan_scale > 1.0:
+            overscan_h = int(math.ceil(requested_h * self._overscan_scale))
+            overscan_w = int(math.ceil(requested_w * self._overscan_scale))
+            self._rectify_resolution = (overscan_h, overscan_w)
+            margin_x = int(round((overscan_w - requested_w) / 2.0))
+            margin_y = int(round((overscan_h - requested_h) / 2.0))
+            self._rectify_intrinsics = RectificationTargetConfig(
+                focal_length=target_intrinsics.focal_length,
+                principal_point=(
+                    target_intrinsics.principal_point[0] + margin_x,
+                    target_intrinsics.principal_point[1] + margin_y,
+                ),
+                resolution_hw=self._rectify_resolution,
+                radial=target_intrinsics.radial,
+                tangential=target_intrinsics.tangential,
+                thin_prism=target_intrinsics.thin_prism,
+                max_overscan_scale=target_intrinsics.max_overscan_scale,
+                safety_margin_px=target_intrinsics.safety_margin_px,
+            )
+            logger.info(
+                "Rectification overscan scale %.3f: %s -> %s",
+                self._overscan_scale,
+                self._requested_resolution,
+                self._rectify_resolution,
+            )
+        else:
+            self._rectify_resolution = self._requested_resolution
+            self._rectify_intrinsics = target_intrinsics
+
+        self._crop_needed = self._rectify_resolution != self._requested_resolution
+        self._crop_origin: tuple[int, int] = (0, 0)
+        if self._crop_needed:
+            overscan_h, overscan_w = self._rectify_resolution
+            crop_x0 = int(round((overscan_w - requested_w) / 2.0))
+            crop_y0 = int(round((overscan_h - requested_h) / 2.0))
+            crop_x0 = max(0, min(crop_x0, overscan_w - requested_w))
+            crop_y0 = max(0, min(crop_y0, overscan_h - requested_h))
+            self._crop_origin = (crop_y0, crop_x0)
+
+        self._map_x, self._map_y = self._build_maps(
+            source_intrinsics, self._rectify_intrinsics
+        )
+        self._distort_map_x: np.ndarray | None = None
+        self._distort_map_y: np.ndarray | None = None
+        if _has_distortion(self._rectify_intrinsics):
+            (
+                self._distort_map_x,
+                self._distort_map_y,
+            ) = self._build_distortion_maps(self._rectify_intrinsics)
+
+    def _build_maps(
+        self,
+        source_intrinsics: sensorsim_pb2.FthetaCameraParam,
+        target_intrinsics: RectificationTargetConfig,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Generate OpenCV remap tables for the provided camera pair."""
+
+        target_resolution = (
+            int(target_intrinsics.resolution_hw[0]),
+            int(target_intrinsics.resolution_hw[1]),
+        )
+        pinhole = _PinholeCamera(
+            target_intrinsics.focal_length,
+            target_intrinsics.principal_point,
+            target_resolution,
+        )
+        rays = pinhole.unit_rays_grid()
+        ftheta = _FthetaCamera(source_intrinsics, self._source_resolution)
+        pixels, valid = ftheta.ray_to_pixel(rays)
+
+        map_x = pixels[..., 0].astype(np.float32)
+        map_y = pixels[..., 1].astype(np.float32)
+        invalid_mask = ~valid
+        map_x[invalid_mask] = -1.0
+        map_y[invalid_mask] = -1.0
+
+        return map_x, map_y
+
+    def _build_distortion_maps(
+        self,
+        target_intrinsics: RectificationTargetConfig,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Create map to reintroduce OpenCV distortion into the pinhole frame."""
+
+        height, width = (
+            int(target_intrinsics.resolution_hw[0]),
+            int(target_intrinsics.resolution_hw[1]),
+        )
+        fx, fy = target_intrinsics.focal_length
+        cx, cy = target_intrinsics.principal_point
+
+        xs = np.arange(width, dtype=np.float64)
+        ys = np.arange(height, dtype=np.float64)
+        grid_x, grid_y = np.meshgrid(xs, ys)
+        distorted_pixels = np.stack((grid_x, grid_y), axis=-1)
+
+        camera_matrix = np.array(
+            [[fx, 0.0, cx], [0.0, fy, cy], [0.0, 0.0, 1.0]],
+            dtype=np.float64,
+        )
+
+        dist = _dist_coeff_vector(target_intrinsics)
+
+        undistorted = cv2.undistortPoints(
+            distorted_pixels.reshape(-1, 1, 2),
+            cameraMatrix=camera_matrix,
+            distCoeffs=dist,
+        ).reshape(-1, 2)
+        undistorted_pixels = np.empty_like(undistorted)
+        undistorted_pixels[:, 0] = undistorted[:, 0] * fx + cx
+        undistorted_pixels[:, 1] = undistorted[:, 1] * fy + cy
+
+        map_x = undistorted_pixels[:, 0].reshape(height, width).astype(np.float32)
+        map_y = undistorted_pixels[:, 1].reshape(height, width).astype(np.float32)
+
+        valid = (
+            (map_x >= -0.5)
+            & (map_x <= width - 0.5)
+            & (map_y >= -0.5)
+            & (map_y <= height - 0.5)
+        )
+        map_x[~valid] = -1.0
+        map_y[~valid] = -1.0
+
+        return map_x, map_y
+
+    def rectify(self, image: np.ndarray) -> np.ndarray:
+        """Return a pinhole-rectified copy of the provided f-theta image."""
+
+        logger.debug(
+            "Rectifying image %s with source resolution %s",
+            image.shape,
+            self._source_resolution,
+        )
+        expected_h, expected_w = self._source_resolution
+        actual_h, actual_w = image.shape[0], image.shape[1]
+        if actual_h != expected_h or actual_w != expected_w:
+            delta_h = actual_h - expected_h
+            delta_w = actual_w - expected_w
+            if 0 <= delta_h <= 1 and 0 <= delta_w <= 1:
+                logger.warning(
+                    "Source resolution %s differs from expected %s; cropping to expected",
+                    (actual_h, actual_w),
+                    self._source_resolution,
+                )
+                image = image[:expected_h, :expected_w]
+            else:
+                raise ValueError(
+                    "Unexpected source resolution: "
+                    f"got {(actual_h, actual_w)}, expected {self._source_resolution}"
+                )
+
+        rectified = cv2.remap(
+            image,
+            self._map_x,
+            self._map_y,
+            interpolation=cv2.INTER_LINEAR,
+            borderMode=cv2.BORDER_CONSTANT,
+            borderValue=0,
+        )
+        if self._distort_map_x is not None and self._distort_map_y is not None:
+            rectified = cv2.remap(
+                rectified,
+                self._distort_map_x,
+                self._distort_map_y,
+                interpolation=cv2.INTER_LINEAR,
+                borderMode=cv2.BORDER_CONSTANT,
+                borderValue=0,
+            )
+        if self._crop_needed:
+            crop_y0, crop_x0 = self._crop_origin
+            crop_y1 = crop_y0 + self._requested_resolution[0]
+            crop_x1 = crop_x0 + self._requested_resolution[1]
+            rectified = rectified[crop_y0:crop_y1, crop_x0:crop_x1]
+        return rectified
+
+
+def _scale_ftheta_intrinsics_to_resolution(
+    intrinsics: sensorsim_pb2.FthetaCameraParam,
+    native_resolution_hw: tuple[int, int],
+    target_resolution_hw: tuple[int, int],
+) -> sensorsim_pb2.FthetaCameraParam:
+    """Return a copy of `intrinsics` scaled to `target_resolution_hw`.
+
+    The y-axis scale is applied through the radial terms (angle→pixel distance),
+    and the x-axis scale is captured by the linear C/D terms so we can represent
+    anisotropic resizing without double-scaling the radius.
+    """
+
+    native_h, native_w = native_resolution_hw
+    target_h, target_w = target_resolution_hw
+    scale_x = target_w / native_w
+    scale_y = target_h / native_h
+    if not np.isclose(scale_x, scale_y, atol=1e-6):
+        logger.warning(
+            "Anisotropic f-theta scaling: native=%s, target=%s, scales=(%.6f, %.6f)",
+            native_resolution_hw,
+            target_resolution_hw,
+            scale_x,
+            scale_y,
+        )
+
+    scaled = sensorsim_pb2.FthetaCameraParam()
+    scaled.CopyFrom(intrinsics)
+
+    scaled.principal_point_x *= scale_x
+    scaled.principal_point_y *= scale_y
+
+    # Scale the radial terms with the vertical factor; the x-axis scale is
+    # injected via the linear C/D terms below to represent anisotropic resizing.
+    radial_scale = scale_y
+    if len(scaled.angle_to_pixeldist_poly):
+        coeffs = (
+            np.asarray(scaled.angle_to_pixeldist_poly, dtype=np.float64) * radial_scale
+        )
+        scaled.angle_to_pixeldist_poly[:] = []
+        scaled.angle_to_pixeldist_poly.extend(coeffs.tolist())
+    if len(scaled.pixeldist_to_angle_poly):
+        powers = np.power(radial_scale, np.arange(len(scaled.pixeldist_to_angle_poly)))
+        coeffs = np.asarray(scaled.pixeldist_to_angle_poly, dtype=np.float64)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            coeffs = np.divide(
+                coeffs,
+                powers,
+                out=np.zeros_like(coeffs),
+                where=powers != 0,
+            )
+        scaled.pixeldist_to_angle_poly[:] = []
+        scaled.pixeldist_to_angle_poly.extend(coeffs.tolist())
+
+    # Apply the remaining x-axis scaling through the linear terms so we do not
+    # double-scale the radius when the resize is anisotropic.
+    linear_c = (
+        intrinsics.linear_cde.linear_c if intrinsics.HasField("linear_cde") else 1.0
+    )
+    linear_d = (
+        intrinsics.linear_cde.linear_d if intrinsics.HasField("linear_cde") else 0.0
+    )
+    linear_e = (
+        intrinsics.linear_cde.linear_e if intrinsics.HasField("linear_cde") else 0.0
+    )
+    x_ratio = scale_x / radial_scale
+    scaled.linear_cde.linear_c = linear_c * x_ratio
+    scaled.linear_cde.linear_d = linear_d * x_ratio
+    scaled.linear_cde.linear_e = linear_e
+
+    return scaled
+
+
+def build_ftheta_rectifier_for_resolution(
+    camera_proto: sensorsim_pb2.AvailableCamerasReturn.AvailableCamera,
+    target_cfg: RectificationTargetConfig,
+    source_resolution_hw: tuple[int, int],
+) -> FthetaToPinholeRectifier:
+    """Construct a rectifier using `camera_proto` scaled to `source_resolution_hw`."""
+
+    if camera_proto.intrinsics.WhichOneof("camera_param") != "ftheta_param":
+        raise ValueError(
+            f"Camera {camera_proto.logical_id} does not provide f-theta intrinsics"
+        )
+
+    native_resolution_hw = (
+        int(camera_proto.intrinsics.resolution_h),
+        int(camera_proto.intrinsics.resolution_w),
+    )
+
+    # The intrinsics are for the native camera resolution, so we need to scale them
+    # to the resolution that the camera was actually rendered at.
+    scaled_intrinsics = _scale_ftheta_intrinsics_to_resolution(
+        intrinsics=camera_proto.intrinsics.ftheta_param,
+        native_resolution_hw=native_resolution_hw,
+        target_resolution_hw=source_resolution_hw,
+    )
+    return FthetaToPinholeRectifier(
+        source_intrinsics=scaled_intrinsics,
+        source_resolution_hw=source_resolution_hw,
+        target_intrinsics=target_cfg,
+    )
+
+
+def build_rectifier_map(
+    rectification_cfg: dict[str, RectificationTargetConfig] | None,
+    desired_cameras: set[str],
+    camera_lookup: dict[str, sensorsim_pb2.AvailableCamerasReturn.AvailableCamera],
+) -> dict[str, FthetaToPinholeRectifier | None]:
+    """Instantiate per-camera rectifiers as requested in the Hydra config."""
+
+    rectifiers: dict[str, FthetaToPinholeRectifier | None] = {
+        logical_id: None for logical_id in desired_cameras
+    }
+    if rectification_cfg is None:
+        return rectifiers
+
+    for logical_id in desired_cameras:
+        target_cfg = rectification_cfg[logical_id]
+        camera_proto = camera_lookup[logical_id]
+
+        rectifiers[logical_id] = build_ftheta_rectifier_for_resolution(
+            camera_proto=camera_proto,
+            target_cfg=target_cfg,
+            source_resolution_hw=(
+                int(camera_proto.intrinsics.resolution_h),
+                int(camera_proto.intrinsics.resolution_w),
+            ),
+        )
+        logger.info("Enabled f-theta→pinhole rectification for %s", logical_id)
+
+    return rectifiers

--- a/tests/test_camera_rectification.py
+++ b/tests/test_camera_rectification.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from alpabridge.simulator import camera_rectification as rect
+from alpabridge.simulator import vavam_model
+from alpabridge.simulator.vavam_model import VAVAMAlpaSimModel
+
+
+@pytest.fixture(autouse=True)
+def _forget_warnings() -> None:
+    rect._WARNED.clear()
+
+
+def _frame(height: int = 4, width: int = 6) -> np.ndarray:
+    return np.zeros((height, width, 3), dtype=np.uint8)
+
+
+@pytest.mark.parametrize("raw", ["1", "true", "YES"])
+def test_rectification_can_be_turned_off(raw: str) -> None:
+    with patch.dict("os.environ", {"ALPABRIDGE_DISABLE_RECTIFICATION": raw}, clear=False):
+        assert rect.rectification_disabled() is True
+
+
+@pytest.mark.parametrize("raw", ["0", "", "no", "off"])
+def test_rectification_is_on_by_default(raw: str) -> None:
+    with patch.dict("os.environ", {"ALPABRIDGE_DISABLE_RECTIFICATION": raw}, clear=False):
+        assert rect.rectification_disabled() is False
+
+
+def test_a_missing_camera_yields_no_rectifier() -> None:
+    assert rect.build_rectifier(None, (1080, 1920)) is None
+
+
+def test_an_unavailable_transform_says_so_once_and_yields_nothing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """alpasim_grpc and cv2 are optional, so this is the common local case."""
+    with patch.object(rect, "default_target_config", side_effect=[None, None]) as target:
+        with caplog.at_level("WARNING"):
+            first = rect.build_rectifier(object(), (1080, 1920))
+            second = rect.build_rectifier(object(), (1080, 1920))
+
+    assert first is None and second is None
+    assert target.call_count == 2
+
+
+def _fake_transform_module(monkeypatch: pytest.MonkeyPatch, builder) -> None:
+    """Stand in for the vendored transform.
+
+    It imports cv2 and alpasim_grpc, neither of which CI installs, so the real
+    module cannot be imported here - which is itself the point: this exercises
+    the wrapper, not NVIDIA's transform.
+    """
+    import sys
+    import types
+
+    module = types.ModuleType("alpabridge.third_party.alpasim_rectification")
+    module.RectificationTargetConfig = lambda **kwargs: SimpleNamespace(**kwargs)
+    module.build_ftheta_rectifier_for_resolution = builder
+    monkeypatch.setitem(sys.modules, "alpabridge.third_party.alpasim_rectification", module)
+
+
+def test_the_target_matches_the_reference_submission(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _fake_transform_module(monkeypatch, lambda *args, **kwargs: None)
+
+    target = rect.default_target_config()
+
+    assert target.focal_length == (1545.0, 1545.0)
+    assert target.principal_point == (960.0, 560.0)
+    assert target.resolution_hw == (1080, 1920)
+
+
+def test_a_transform_that_cannot_be_built_falls_back_and_warns_once(
+    caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def _boom(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("no polynomial")
+
+    _fake_transform_module(monkeypatch, _boom)
+
+    with caplog.at_level("WARNING"):
+        assert rect.build_rectifier(object(), (1080, 1920)) is None
+        assert rect.build_rectifier(object(), (1080, 1920)) is None
+
+    warnings = [r for r in caplog.records if "unrectified" in r.getMessage()]
+    assert len(warnings) == 1
+
+
+def test_a_buildable_transform_is_returned(monkeypatch: pytest.MonkeyPatch) -> None:
+    sentinel = object()
+    _fake_transform_module(monkeypatch, lambda *args, **kwargs: sentinel)
+
+    assert rect.build_rectifier(object(), (1080, 1920)) is sentinel
+
+
+def test_no_rectifier_returns_the_frame_untouched() -> None:
+    image = _frame()
+
+    assert rect.rectify_image(None, image) is image
+
+
+def test_a_working_rectifier_output_is_what_comes_back() -> None:
+    image = _frame()
+    rectified = _frame(8, 8)
+    rectifier = SimpleNamespace(rectify=lambda _: rectified)
+
+    assert np.array_equal(rect.rectify_image(rectifier, image), rectified)
+
+
+def test_a_failing_rectifier_returns_the_original_and_warns_once(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    image = _frame()
+
+    def _boom(_: np.ndarray) -> np.ndarray:
+        raise ValueError("bad remap")
+
+    rectifier = SimpleNamespace(rectify=_boom)
+    with caplog.at_level("WARNING"):
+        first = rect.rectify_image(rectifier, image)
+        second = rect.rectify_image(rectifier, image)
+
+    assert first is image and second is image
+    warnings = [r for r in caplog.records if "as rendered" in r.getMessage()]
+    assert len(warnings) == 1
+
+
+def _model_with(camera_id: str = "front") -> VAVAMAlpaSimModel:
+    """A VAVAM adapter without its weights: only the frame path is under test."""
+    model = object.__new__(VAVAMAlpaSimModel)
+    model._camera_ids = [camera_id]
+    model._rectifiers = {}
+    return model
+
+
+def _prediction_input(source_camera_id: str = "camera_front_wide_120fov") -> SimpleNamespace:
+    frame = SimpleNamespace(image=None, source_camera_id=source_camera_id)
+    return SimpleNamespace(
+        camera_images={"front": [frame]},
+        camera_protos={source_camera_id: object()},
+    )
+
+
+def test_the_rectified_frame_is_what_reaches_inference() -> None:
+    model = _model_with()
+    prediction_input = _prediction_input()
+    image = _frame(1080, 1920)
+    rectified = _frame(1080, 1920)
+    rectified[0, 0, 0] = 7
+
+    with patch.object(vavam_model, "build_rectifier") as build:
+        build.return_value = SimpleNamespace(rectify=lambda _: rectified)
+        out = model._rectified(prediction_input, image)
+
+    assert int(out[0, 0, 0]) == 7
+
+
+def test_a_rectifier_is_built_once_per_camera_and_size() -> None:
+    model = _model_with()
+    prediction_input = _prediction_input()
+    image = _frame(1080, 1920)
+
+    with patch.object(vavam_model, "build_rectifier") as build:
+        build.return_value = None
+        for _ in range(3):
+            model._rectified(prediction_input, image)
+        model._rectified(prediction_input, _frame(1080, 1916))
+
+    # Three identical frames share one rectifier; a new size needs its own.
+    assert build.call_count == 2
+
+
+def test_opting_out_skips_the_transform_entirely() -> None:
+    model = _model_with()
+    prediction_input = _prediction_input()
+    image = _frame(1080, 1920)
+
+    with patch.dict("os.environ", {"ALPABRIDGE_DISABLE_RECTIFICATION": "1"}, clear=False):
+        with patch.object(vavam_model, "build_rectifier") as build:
+            out = model._rectified(prediction_input, image)
+
+    assert out is image
+    build.assert_not_called()
+
+
+def test_a_frame_with_no_source_camera_is_left_alone() -> None:
+    model = _model_with()
+    prediction_input = _prediction_input(source_camera_id="")
+
+    image = _frame(1080, 1920)
+    assert model._rectified(prediction_input, image) is image
+
+
+def test_an_undecodable_frame_is_left_alone() -> None:
+    model = _model_with()
+    prediction_input = _prediction_input()
+
+    image = np.zeros((1,), dtype=np.uint8)
+    assert model._rectified(prediction_input, image) is image

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,7 @@ alpasim = [
 ]
 dev = [
     { name = "build" },
+    { name = "opencv-python-headless" },
     { name = "pillow" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -33,6 +34,9 @@ dev = [
 ]
 driver = [
     { name = "pillow" },
+]
+rectify = [
+    { name = "opencv-python-headless" },
 ]
 viz = [
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -46,6 +50,8 @@ requires-dist = [
     { name = "huggingface-hub", marker = "extra == 'alpasim'", specifier = ">=0.30" },
     { name = "matplotlib", marker = "extra == 'viz'", specifier = ">=3.8" },
     { name = "numpy", specifier = ">=1.26" },
+    { name = "opencv-python-headless", marker = "extra == 'dev'", specifier = ">=4.10" },
+    { name = "opencv-python-headless", marker = "extra == 'rectify'", specifier = ">=4.10" },
     { name = "pillow", marker = "extra == 'dev'", specifier = ">=10" },
     { name = "pillow", marker = "extra == 'driver'", specifier = ">=10" },
     { name = "pillow", marker = "extra == 'viz'", specifier = ">=10" },
@@ -56,7 +62,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6" },
 ]
-provides-extras = ["dev", "alpasim", "viz", "driver"]
+provides-extras = ["dev", "alpasim", "viz", "rectify", "driver"]
 
 [[package]]
 name = "anyio"
@@ -1097,6 +1103,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
     { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
     { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
+]
+
+[[package]]
+name = "opencv-python-headless"
+version = "5.0.0.93"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/99/76b7c80252aa83c1af16393454aafd125a0287101afe8deb0a6821af0e30/opencv_python_headless-5.0.0.93.tar.gz", hash = "sha256:b82f9831daab90b725c7c1ee1b36cb5732c367096ac76d119e64e14eb70d5f3c", size = 81817738, upload-time = "2026-07-02T07:01:06.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/7c/8c8097891c509d98cd128493835c95631c80be6a8f37ed9d25716c2e16f1/opencv_python_headless-5.0.0.93-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:030ca5e0837a2963ab36ef896baa9767eb8d2b83353fb28af5a521e40dd8756f", size = 48322581, upload-time = "2026-07-02T05:50:34.207Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8c/eab2ad388c3cbab2a350c10c2ef19ce6bd099240afc31789032c996bab52/opencv_python_headless-5.0.0.93-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:1e55af3abfb462eeeabe5c775f12bdb36216d8a93a3583d69e6bd6e1d6ba7d00", size = 34782894, upload-time = "2026-07-02T05:51:39.856Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/78/afca939f40ffe2b2380bfa86f812b2f7d4acc5a27b27dc41b49cad7ce7b4/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10818d91510e05c04568ae12b5cd120779c70c01bf897b001a6221fe430df80f", size = 36521085, upload-time = "2026-07-02T06:55:24.429Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/97/8170e9819764c47e436c130d3ff6cfb73b58f923eae9d3a03d8982b04aec/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:09a872a157c1376ab922a69bbf22f9a95bcc7b658a9d8b436a60212b02b2eeb4", size = 56563598, upload-time = "2026-07-02T06:55:47.355Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/98/1a28a7101e31801042b3098871a74b76c61581d328ef40774ff4edb53a56/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:840bd717c21e5c11cadadc022a823315ea417f961213d06b4df010e019eb16f4", size = 39648433, upload-time = "2026-07-02T06:56:04.255Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/21/f6ef335f6e65724aa78b8d792b48d40a48c381715f1e62f5a5049e09d07e/opencv_python_headless-5.0.0.93-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ed709fdf9aa0bd1f2ed8549e71d19449b03a675bb581eb292285f6861953be37", size = 61204038, upload-time = "2026-07-02T06:56:41.823Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/8f/b8756467ea991449a293797f6b3fa80fcfdd29598a0a60d1cd5715b96e61/opencv_python_headless-5.0.0.93-cp37-abi3-win32.whl", hash = "sha256:c6bcd96b185975ea240d22cfdb15a1f6d080cc95264cfbe2621f21bb144d89b9", size = 35411237, upload-time = "2026-07-02T05:50:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/88/763b967f7efd7226b82c9fae16d560cba049b1f0c036647e65c610fd636e/opencv_python_headless-5.0.0.93-cp37-abi3-win_amd64.whl", hash = "sha256:829717b6a95554f273e49e357cee3b3a2a26b6f4842fbc1bed2b45bdd8f87e0e", size = 43825962, upload-time = "2026-07-02T05:50:09.627Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Adopted, not reimplemented

`src/alpabridge/third_party/alpasim_rectification.py` is NVIDIA's
`e2e_challenge/sample_submission_vavam/vavam_challenge/rectification.py`,
vendored **verbatim** from commit `d9bc5cf714`. Its Apache-2.0 header and
copyright stay in the file; origin, commit and sha256 are recorded in
`third_party/NOTICE`; ruff is configured to leave the directory alone.

Byte-identical is the point: a rectified frame here matches the reference
submission's, and the file can be diffed when upstream moves. A rewrite could
offer neither.

## Why it is needed

The rig renders f-theta frames and VAVAM expects rectified pinhole ones.
Nothing in this repo bridged that, so the adapter handed the model a projection
it was not trained on. Resizing and cropping cannot correct a projection
difference; only rectification can.

## The AlpaBridge side

`simulator/camera_rectification.py` owns every decision this repo makes:

- one rectifier per camera and delivered size, built lazily and cached;
- the target pinhole matches the reference submission's;
- `cv2` and `alpasim_grpc` are both optional, so a missing dependency, an
  unbuildable rectifier, or a remap that throws each warn once and return the
  frame **as rendered** — which is what this adapter did before, so no failure
  path is worse than not having rectification at all;
- on by default, since that is what the model expects;
  `ALPABRIDGE_DISABLE_RECTIFICATION=1` opts out.

Frames also needed their raw camera message, not just the parsed calibration:
the f-theta polynomial lives in the proto and `CameraCalibration` deliberately
does not carry it.

## Verified, and what is not

421 passed, 1 skipped (401 before). 20 new tests cover the opt-out, the target
config, build failure, remap failure, the cache keyed by camera and size, and
every path that must leave a frame untouched.

**The transform itself is not exercised in CI**, which has neither `cv2`'s
companion `alpasim_grpc` nor a built proto package — the vendored module cannot
be imported there. What is tested is the wrapper. This is a correctness change;
no end-to-end run has been made to confirm any effect on behaviour.
