### PR TITLE
docs: state the camera contract in general terms

### DIFF
--- a/src/alpabridge/driver/driver_service.py
+++ b/src/alpabridge/driver/driver_service.py
@@ -889,9 +889,9 @@ def _calibrations_for_delivered_images(
 ) -> dict[str, CameraCalibration]:
     """Express each calibration for the image size that actually arrived.
 
-    The declared resolution is the native camera's; the challenge rig delivers
-    JPEGs whose width can differ per scene, and intrinsics are only meaningful
-    against the image they are applied to.
+    The declared resolution is the native camera's; a rig can deliver JPEGs of a
+    different size, and intrinsics are only meaningful against the image they
+    are applied to.
     """
     scaled: dict[str, CameraCalibration] = {}
     for camera_id, calibration in calibrations.items():

--- a/src/alpabridge/simulator/camera_rectification.py
+++ b/src/alpabridge/simulator/camera_rectification.py
@@ -1,9 +1,9 @@
 """Rectify f-theta rig frames into the pinhole view a policy expects.
 
-The rig's 120 degree cameras are f-theta and place their optical centre about
-200 px below the frame centre; models like VAVAM were trained on rectified,
-roughly centred pinhole images. Feeding one the other is a silent domain gap
-that no amount of cropping fixes.
+Rigs can render f-theta frames whose optical centre sits away from the frame
+centre, while models like VAVAM were trained on rectified, roughly centred
+pinhole images. Feeding one the other is a silent domain gap that resizing and
+cropping cannot close, since they do not change the projection.
 
 The transform itself is AlpaSim's, vendored verbatim under
 `alpabridge/third_party/` so it matches the reference submission exactly. This

--- a/tests/test_camera_calibration.py
+++ b/tests/test_camera_calibration.py
@@ -76,8 +76,8 @@ def test_scaling_moves_the_pixel_terms_and_leaves_the_rest() -> None:
     calibration = calibration_from_available_camera(_pinhole_camera())
     assert calibration is not None
 
-    # The official set delivers 1916x1080 on some scenes: width scales, height
-    # does not, so the two axes must be treated separately.
+    # A delivered width that differs from the declared one while the height
+    # matches: the two axes must be treated separately.
     scaled = calibration.scaled_to(1916, 1080)
 
     assert scaled.width == 1916


### PR DESCRIPTION
Three comments pinned a general mechanism to one rig's measured geometry and one evaluation set's frame sizes. The code reads whatever the calibration reports and never depended on those specifics, so the comments now describe the contract rather than an instance of it. No behaviour change.